### PR TITLE
feat: Mailtrap sandbox mode for local testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ R2_PUBLIC_URL=
 
 # Email (Mailtrap)
 MAILTRAP_API_TOKEN=
+MAILTRAP_TEST_INBOX_ID=
 EMAIL_FROM=noreply@fooshop.ai
 
 # App

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -8,7 +8,14 @@ function getMailtrap(): MailtrapClient {
   if (!_mailtrap) {
     const token = process.env.MAILTRAP_API_TOKEN;
     if (!token) throw new Error("MAILTRAP_API_TOKEN is not set");
-    _mailtrap = new MailtrapClient({ token });
+    const testInboxId = process.env.MAILTRAP_TEST_INBOX_ID;
+    _mailtrap = new MailtrapClient({
+      token,
+      ...(testInboxId && {
+        sandbox: true,
+        testInboxId: Number(testInboxId),
+      }),
+    });
   }
   return _mailtrap;
 }


### PR DESCRIPTION
## Summary
- Add `MAILTRAP_TEST_INBOX_ID` env var to toggle sandbox mode
- When set, emails go to Mailtrap test inbox instead of real delivery
- No impact on production (env var not set = real sending)

## Test plan
- [x] Tested locally with sandbox inbox — email arrives in Mailtrap