### PR TITLE
[Issue #26] Dashboard analytics: revenue, top products, conversion rate

### DIFF
--- a/docs/superpowers/plans/2026-03-12-dashboard-analytics.md
+++ b/docs/superpowers/plans/2026-03-12-dashboard-analytics.md
@@ -1,0 +1,1448 @@
+# Dashboard Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance the creator dashboard with interactive analytics: revenue chart, KPI cards with period comparisons, top products, traffic sources, conversion funnel, and coupon performance.
+
+**Architecture:** Single API endpoint (`GET /api/analytics?period=30d`) runs 6 parallel aggregation queries scoped to the authenticated creator. A client component (`DashboardAnalytics`) fetches data and renders Recharts-based visualizations. The existing server-component dashboard page embeds this client component.
+
+**Tech Stack:** Next.js 15 App Router, Drizzle ORM (PostgreSQL), Recharts, Tailwind CSS, Auth.js
+
+**Spec:** `docs/superpowers/specs/2026-03-12-dashboard-analytics-design.md`
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|---------------|
+| Create | `src/app/api/analytics/route.ts` | API endpoint: auth, period parsing, 6 parallel queries, JSON response |
+| Create | `src/components/dashboard/period-selector.tsx` | Tab toggle for time period (7d/30d/90d/all) |
+| Create | `src/components/dashboard/kpi-cards.tsx` | 4-card grid with value + % change badge |
+| Create | `src/components/dashboard/revenue-chart.tsx` | Recharts AreaChart with gradient fill |
+| Create | `src/components/dashboard/top-products.tsx` | Ranked list (top 5 by revenue) |
+| Create | `src/components/dashboard/traffic-sources.tsx` | Horizontal bar chart by source |
+| Create | `src/components/dashboard/conversion-funnel.tsx` | Stepped bars: views → intents → orders |
+| Create | `src/components/dashboard/coupon-performance.tsx` | Coupon list with metrics |
+| Create | `src/components/dashboard/dashboard-analytics.tsx` | Client component orchestrator: fetches data, renders all analytics widgets |
+| Modify | `src/app/(platform)/dashboard/page.tsx` | Replace static stat cards with `DashboardAnalytics` component |
+
+---
+
+## Chunk 1: API Endpoint + Dependency Setup
+
+### Task 1: Install Recharts
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install recharts**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-26-dashboard-analytics
+pnpm add recharts
+```
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+pnpm list recharts
+```
+
+Expected: `recharts 2.x.x`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "chore: add recharts dependency (#26)"
+```
+
+---
+
+### Task 2: Analytics API Endpoint
+
+**Files:**
+- Create: `src/app/api/analytics/route.ts`
+
+**Reference:** Auth pattern from `src/app/api/orders/export/route.ts` — `auth()` → session check → creator lookup → query.
+
+**Reference:** Schema at `src/db/schema.ts` — tables: `orders` (lines 196-214), `pageViews` (lines 230-238), `buyIntents` (lines 240-251), `products` (lines 151-173), `coupons` (lines 175-194), `creators` (lines 133-149).
+
+**Key constraints:**
+- `pageViews` has NO `creatorId` — must join through `products.creatorId` (for product views) or `creators.slug` (for store views via `storeSlug`)
+- All revenue = `amountCents - platformFeeCents` (net to creator)
+- All order queries filter `status = 'completed'`
+- Period "all" returns `null` for `changes`
+
+- [ ] **Step 1: Create the API route file**
+
+```typescript
+// src/app/api/analytics/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import {
+  orders,
+  creators,
+  products,
+  pageViews,
+  buyIntents,
+  coupons,
+} from "@/db/schema";
+import { eq, sql, and, gte, lt, isNotNull } from "drizzle-orm";
+
+type Period = "7d" | "30d" | "90d" | "all";
+
+function parsePeriod(value: string | null): Period {
+  if (value === "7d" || value === "30d" || value === "90d" || value === "all")
+    return value;
+  return "30d";
+}
+
+function periodToDays(period: Period): number | null {
+  switch (period) {
+    case "7d": return 7;
+    case "30d": return 30;
+    case "90d": return 90;
+    case "all": return null;
+  }
+}
+
+function dateRange(days: number | null): { start: Date | null; end: Date } {
+  const end = new Date();
+  if (days === null) return { start: null, end };
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  start.setHours(0, 0, 0, 0);
+  return { start, end };
+}
+
+function previousRange(days: number): { start: Date; end: Date } {
+  const end = new Date();
+  end.setDate(end.getDate() - days);
+  end.setHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setDate(start.getDate() - days);
+  return { start, end };
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const creator = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.userId, session.user.id))
+    .then((rows) => rows[0]);
+
+  if (!creator) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  const period = parsePeriod(request.nextUrl.searchParams.get("period"));
+  const days = periodToDays(period);
+  const { start } = dateRange(days);
+
+  const creatorId = creator.id;
+  const creatorSlug = creator.slug;
+
+  // ── 1. KPIs (current + previous period) ──────────────────────────────
+
+  async function queryOrderKpis(rangeStart: Date | null, rangeEnd: Date | null) {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (rangeStart) conditions.push(gte(orders.createdAt, rangeStart));
+    if (rangeEnd) conditions.push(lt(orders.createdAt, rangeEnd));
+
+    const [result] = await db
+      .select({
+        revenue: sql<number>`coalesce(sum(${orders.amountCents} - ${orders.platformFeeCents}), 0)`,
+        orderCount: sql<number>`count(*)`,
+      })
+      .from(orders)
+      .where(and(...conditions));
+
+    return {
+      revenue: Number(result.revenue),
+      orders: Number(result.orderCount),
+    };
+  }
+
+  async function queryPageViewCount(rangeStart: Date | null, rangeEnd: Date | null) {
+    // Product page views (join through products)
+    const productConditions = [
+      isNotNull(pageViews.productId),
+      eq(products.creatorId, creatorId),
+    ];
+    if (rangeStart) productConditions.push(gte(pageViews.createdAt, rangeStart));
+    if (rangeEnd) productConditions.push(lt(pageViews.createdAt, rangeEnd));
+
+    const [productViews] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(pageViews)
+      .innerJoin(products, eq(pageViews.productId, products.id))
+      .where(and(...productConditions));
+
+    // Store page views (join through creators)
+    const storeConditions = [
+      isNotNull(pageViews.storeSlug),
+      eq(creators.slug, creatorSlug),
+    ];
+    if (rangeStart) storeConditions.push(gte(pageViews.createdAt, rangeStart));
+    if (rangeEnd) storeConditions.push(lt(pageViews.createdAt, rangeEnd));
+
+    const [storeViews] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(pageViews)
+      .innerJoin(creators, eq(pageViews.storeSlug, creators.slug))
+      .where(and(...storeConditions));
+
+    return Number(productViews.count) + Number(storeViews.count);
+  }
+
+  async function queryProductPageViewCount(rangeStart: Date | null, rangeEnd: Date | null) {
+    const conditions = [
+      isNotNull(pageViews.productId),
+      eq(products.creatorId, creatorId),
+    ];
+    if (rangeStart) conditions.push(gte(pageViews.createdAt, rangeStart));
+    if (rangeEnd) conditions.push(lt(pageViews.createdAt, rangeEnd));
+
+    const [result] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(pageViews)
+      .innerJoin(products, eq(pageViews.productId, products.id))
+      .where(and(...conditions));
+
+    return Number(result.count);
+  }
+
+  // ── 2. Revenue over time ─────────────────────────────────────────────
+
+  async function queryRevenueOverTime() {
+    const useWeekly = period === "90d" || period === "all";
+    const dateTrunc = useWeekly ? "week" : "day";
+
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    const rows = await db
+      .select({
+        date: sql<string>`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})::date::text`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+      })
+      .from(orders)
+      .where(and(...conditions))
+      .groupBy(sql`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})`)
+      .orderBy(sql`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})`);
+
+    return rows.map((r) => ({ date: r.date, revenue: Number(r.revenue) }));
+  }
+
+  // ── 3. Top products ──────────────────────────────────────────────────
+
+  async function queryTopProducts() {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    return db
+      .select({
+        id: products.id,
+        title: products.title,
+        sales: sql<number>`count(*)`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+      })
+      .from(orders)
+      .innerJoin(products, eq(orders.productId, products.id))
+      .where(and(...conditions))
+      .groupBy(products.id, products.title)
+      .orderBy(sql`sum(${orders.amountCents} - ${orders.platformFeeCents}) desc`)
+      .limit(5)
+      .then((rows) =>
+        rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          sales: Number(r.sales),
+          revenue: Number(r.revenue),
+        }))
+      );
+  }
+
+  // ── 4. Traffic sources ───────────────────────────────────────────────
+
+  async function queryTrafficSources() {
+    // Product page views by source
+    const productConditions = [
+      isNotNull(pageViews.productId),
+      eq(products.creatorId, creatorId),
+    ];
+    if (start) productConditions.push(gte(pageViews.createdAt, start));
+
+    const productBySource = await db
+      .select({
+        source: pageViews.source,
+        count: sql<number>`count(*)`,
+      })
+      .from(pageViews)
+      .innerJoin(products, eq(pageViews.productId, products.id))
+      .where(and(...productConditions))
+      .groupBy(pageViews.source);
+
+    // Store page views by source
+    const storeConditions = [
+      isNotNull(pageViews.storeSlug),
+      eq(creators.slug, creatorSlug),
+    ];
+    if (start) storeConditions.push(gte(pageViews.createdAt, start));
+
+    const storeBySource = await db
+      .select({
+        source: pageViews.source,
+        count: sql<number>`count(*)`,
+      })
+      .from(pageViews)
+      .innerJoin(creators, eq(pageViews.storeSlug, creators.slug))
+      .where(and(...storeConditions))
+      .groupBy(pageViews.source);
+
+    // Merge counts by source
+    const merged = new Map<string, number>();
+    for (const row of [...productBySource, ...storeBySource]) {
+      merged.set(row.source, (merged.get(row.source) ?? 0) + Number(row.count));
+    }
+
+    const total = Array.from(merged.values()).reduce((a, b) => a + b, 0);
+    return Array.from(merged.entries())
+      .map(([source, count]) => ({
+        source,
+        count,
+        percentage: total > 0 ? Math.round((count / total) * 1000) / 10 : 0,
+      }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // ── 5. Conversion funnel ─────────────────────────────────────────────
+
+  async function queryConversionFunnel() {
+    const pvCount = await queryProductPageViewCount(start, null);
+
+    const biConditions = [eq(buyIntents.creatorId, creatorId)];
+    if (start) biConditions.push(gte(buyIntents.createdAt, start));
+    const [bi] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(buyIntents)
+      .where(and(...biConditions));
+
+    const oConditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (start) oConditions.push(gte(orders.createdAt, start));
+    const [o] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(orders)
+      .where(and(...oConditions));
+
+    return {
+      pageViews: pvCount,
+      buyIntents: Number(bi.count),
+      orders: Number(o.count),
+    };
+  }
+
+  // ── 6. Coupon performance ────────────────────────────────────────────
+
+  async function queryCouponPerformance() {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+      isNotNull(orders.couponId),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    const rows = await db
+      .select({
+        id: coupons.id,
+        code: coupons.code,
+        discountType: coupons.discountType,
+        discountValue: coupons.discountValue,
+        redemptions: sql<number>`count(*)`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+        active: coupons.active,
+      })
+      .from(orders)
+      .innerJoin(coupons, eq(orders.couponId, coupons.id))
+      .where(and(...conditions))
+      .groupBy(
+        coupons.id,
+        coupons.code,
+        coupons.discountType,
+        coupons.discountValue,
+        coupons.active
+      );
+
+    return rows.map((r) => ({
+      id: r.id,
+      code: r.code,
+      discountType: r.discountType,
+      discountValue: r.discountValue,
+      redemptions: Number(r.redemptions),
+      revenue: Number(r.revenue),
+      active: r.active,
+    }));
+  }
+
+  // ── Execute all in parallel ──────────────────────────────────────────
+
+  const currentKpis = queryOrderKpis(start, null);
+  const currentPageViews = queryPageViewCount(start, null);
+  const currentProductPageViews = queryProductPageViewCount(start, null);
+
+  let previousKpis: Promise<{ revenue: number; orders: number }>;
+  let previousPageViews: Promise<number>;
+  let previousProductPageViews: Promise<number>;
+
+  if (days !== null) {
+    const prev = previousRange(days);
+    previousKpis = queryOrderKpis(prev.start, prev.end);
+    previousPageViews = queryPageViewCount(prev.start, prev.end);
+    previousProductPageViews = queryProductPageViewCount(prev.start, prev.end);
+  } else {
+    previousKpis = Promise.resolve({ revenue: 0, orders: 0 });
+    previousPageViews = Promise.resolve(0);
+    previousProductPageViews = Promise.resolve(0);
+  }
+
+  const [
+    curKpis,
+    curPV,
+    curPPV,
+    prevKpis,
+    prevPV,
+    prevPPV,
+    revenueOverTime,
+    topProducts,
+    trafficSources,
+    conversionFunnel,
+    couponPerformance,
+  ] = await Promise.all([
+    currentKpis,
+    currentPageViews,
+    currentProductPageViews,
+    previousKpis,
+    previousPageViews,
+    previousProductPageViews,
+    queryRevenueOverTime(),
+    queryTopProducts(),
+    queryTrafficSources(),
+    queryConversionFunnel(),
+    queryCouponPerformance(),
+  ]);
+
+  const conversionRate = curPPV > 0
+    ? Math.round((curKpis.orders / curPPV) * 1000) / 10
+    : 0;
+  const prevConversionRate = prevPPV > 0
+    ? Math.round((prevKpis.orders / prevPPV) * 1000) / 10
+    : 0;
+
+  function pctChange(current: number, previous: number): number | null {
+    if (days === null) return null;
+    if (previous === 0) return current > 0 ? 100 : 0;
+    return Math.round(((current - previous) / previous) * 1000) / 10;
+  }
+
+  return NextResponse.json({
+    kpis: {
+      revenue: curKpis.revenue,
+      orders: curKpis.orders,
+      conversionRate,
+      pageViews: curPV,
+      changes: {
+        revenue: pctChange(curKpis.revenue, prevKpis.revenue),
+        orders: pctChange(curKpis.orders, prevKpis.orders),
+        conversionRate: pctChange(conversionRate, prevConversionRate),
+        pageViews: pctChange(curPV, prevPV),
+      },
+    },
+    revenueOverTime,
+    topProducts,
+    trafficSources,
+    conversionFunnel,
+    couponPerformance,
+  });
+}
+```
+
+- [ ] **Step 2: Build to verify no TypeScript errors**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-26-dashboard-analytics
+pnpm build 2>&1 | tail -20
+```
+
+Expected: Build succeeds, route appears as `ƒ /api/analytics`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/analytics/route.ts
+git commit -m "feat: add analytics API endpoint with 6 parallel queries (#26)
+
+Single GET /api/analytics?period=30d endpoint returning KPIs with period
+comparison, revenue over time, top products, traffic sources, conversion
+funnel, and coupon performance. All queries scoped to authenticated creator."
+```
+
+---
+
+## Chunk 2: Dashboard UI Components
+
+### Task 3: PeriodSelector Component
+
+**Files:**
+- Create: `src/components/dashboard/period-selector.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/period-selector.tsx
+"use client";
+
+const PERIODS = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+  { value: "all", label: "All" },
+] as const;
+
+export type Period = (typeof PERIODS)[number]["value"];
+
+export function PeriodSelector({
+  value,
+  onChange,
+}: {
+  value: Period;
+  onChange: (period: Period) => void;
+}) {
+  return (
+    <div className="flex gap-1 bg-surface border border-border rounded-lg p-1">
+      {PERIODS.map((p) => (
+        <button
+          key={p.value}
+          onClick={() => onChange(p.value)}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            value === p.value
+              ? "bg-accent text-white"
+              : "text-muted hover:text-ink"
+          }`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/period-selector.tsx
+git commit -m "feat: add PeriodSelector component (#26)"
+```
+
+---
+
+### Task 4: KpiCards Component
+
+**Files:**
+- Create: `src/components/dashboard/kpi-cards.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/kpi-cards.tsx
+"use client";
+
+interface KpiData {
+  revenue: number;
+  orders: number;
+  conversionRate: number;
+  pageViews: number;
+  changes: {
+    revenue: number | null;
+    orders: number | null;
+    conversionRate: number | null;
+    pageViews: number | null;
+  };
+}
+
+function formatCurrency(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatChange(value: number | null): { text: string; color: string } | null {
+  if (value === null) return null;
+  const sign = value > 0 ? "+" : "";
+  const color = value > 0 ? "text-green-600" : value < 0 ? "text-red-500" : "text-muted";
+  return { text: `${sign}${value}%`, color };
+}
+
+export function KpiCards({ kpis }: { kpis: KpiData }) {
+  const cards = [
+    { label: "Revenue", value: formatCurrency(kpis.revenue), change: kpis.changes.revenue },
+    { label: "Orders", value: kpis.orders.toLocaleString(), change: kpis.changes.orders },
+    { label: "Conversion Rate", value: `${kpis.conversionRate}%`, change: kpis.changes.conversionRate },
+    { label: "Page Views", value: kpis.pageViews.toLocaleString(), change: kpis.changes.pageViews },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => {
+        const change = formatChange(card.change);
+        return (
+          <div
+            key={card.label}
+            className="bg-surface border border-border rounded-xl p-5"
+          >
+            <p className="text-sm text-muted">{card.label}</p>
+            <p className="text-2xl font-bold mt-1">{card.value}</p>
+            {change && (
+              <p className={`text-xs mt-1 ${change.color}`}>
+                {change.text} vs prev
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/kpi-cards.tsx
+git commit -m "feat: add KpiCards component with period comparison (#26)"
+```
+
+---
+
+### Task 5: RevenueChart Component
+
+**Files:**
+- Create: `src/components/dashboard/revenue-chart.tsx`
+
+**Reference:** Recharts docs — `AreaChart`, `Area`, `XAxis`, `YAxis`, `Tooltip`, `ResponsiveContainer`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/revenue-chart.tsx
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface DataPoint {
+  date: string;
+  revenue: number;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatCurrency(cents: number): string {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+export function RevenueChart({ data }: { data: DataPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Revenue Over Time</h3>
+        <div className="flex items-center justify-center h-48 text-muted text-sm">
+          No sales yet
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Revenue Over Time</h3>
+      <ResponsiveContainer width="100%" height={240}>
+        <AreaChart data={data}>
+          <defs>
+            <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity={0.3} />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity={0.02} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatDate}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted)", fontSize: 12 }}
+          />
+          <YAxis
+            tickFormatter={formatCurrency}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted)", fontSize: 12 }}
+            width={60}
+          />
+          <Tooltip
+            formatter={(value: number) => [formatCurrency(value), "Revenue"]}
+            labelFormatter={formatDate}
+            contentStyle={{
+              backgroundColor: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: "8px",
+              fontSize: "13px",
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="revenue"
+            stroke="var(--accent)"
+            strokeWidth={2}
+            fill="url(#revenueGradient)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/revenue-chart.tsx
+git commit -m "feat: add RevenueChart component with Recharts AreaChart (#26)"
+```
+
+---
+
+### Task 6: TopProducts Component
+
+**Files:**
+- Create: `src/components/dashboard/top-products.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/top-products.tsx
+"use client";
+
+interface Product {
+  id: string;
+  title: string;
+  sales: number;
+  revenue: number;
+}
+
+export function TopProducts({ products }: { products: Product[] }) {
+  if (products.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Top Products</h3>
+        <p className="text-muted text-sm">
+          No sales yet — publish a product to get started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Top Products</h3>
+      <div className="space-y-4">
+        {products.map((product) => (
+          <div key={product.id} className="flex justify-between items-center">
+            <div>
+              <p className="text-sm font-medium">{product.title}</p>
+              <p className="text-xs text-muted">
+                {product.sales} {product.sales === 1 ? "sale" : "sales"}
+              </p>
+            </div>
+            <p className="text-sm font-semibold">
+              ${(product.revenue / 100).toFixed(2)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/top-products.tsx
+git commit -m "feat: add TopProducts component (#26)"
+```
+
+---
+
+### Task 7: TrafficSources Component
+
+**Files:**
+- Create: `src/components/dashboard/traffic-sources.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/traffic-sources.tsx
+"use client";
+
+interface SourceData {
+  source: string;
+  count: number;
+  percentage: number;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  web: "Web",
+  mcp: "MCP (AI Agents)",
+  api: "API",
+};
+
+const SOURCE_COLORS: Record<string, string> = {
+  web: "bg-accent",
+  mcp: "bg-purple-500",
+  api: "bg-green-500",
+};
+
+export function TrafficSources({ sources }: { sources: SourceData[] }) {
+  if (sources.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Traffic Sources</h3>
+        <p className="text-muted text-sm">No visits recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Traffic Sources</h3>
+      <div className="space-y-4">
+        {sources.map((s) => (
+          <div key={s.source}>
+            <div className="flex justify-between text-xs mb-1">
+              <span>{SOURCE_LABELS[s.source] ?? s.source}</span>
+              <span className="text-muted">
+                {s.count.toLocaleString()} ({s.percentage}%)
+              </span>
+            </div>
+            <div className="h-2 bg-border rounded-full">
+              <div
+                className={`h-full rounded-full ${SOURCE_COLORS[s.source] ?? "bg-accent"}`}
+                style={{ width: `${Math.max(s.percentage, 2)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/traffic-sources.tsx
+git commit -m "feat: add TrafficSources component (#26)"
+```
+
+---
+
+### Task 8: ConversionFunnel Component
+
+**Files:**
+- Create: `src/components/dashboard/conversion-funnel.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/conversion-funnel.tsx
+"use client";
+
+interface FunnelData {
+  pageViews: number;
+  buyIntents: number;
+  orders: number;
+}
+
+export function ConversionFunnel({ funnel }: { funnel: FunnelData }) {
+  const maxVal = Math.max(funnel.pageViews, 1);
+
+  const steps = [
+    {
+      label: "Page Views",
+      value: funnel.pageViews,
+      pct: null as string | null,
+    },
+    {
+      label: "Buy Intent (clicked Buy)",
+      value: funnel.buyIntents,
+      pct:
+        funnel.pageViews > 0
+          ? `${((funnel.buyIntents / funnel.pageViews) * 100).toFixed(1)}%`
+          : "0%",
+    },
+    {
+      label: "Completed Orders",
+      value: funnel.orders,
+      pct:
+        funnel.pageViews > 0
+          ? `${((funnel.orders / funnel.pageViews) * 100).toFixed(1)}%`
+          : "0%",
+    },
+  ];
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Conversion Funnel</h3>
+      <div className="space-y-3">
+        {steps.map((step, i) => (
+          <div key={step.label}>
+            <div className="flex justify-between text-xs mb-1">
+              <span>{step.label}</span>
+              <span className="text-muted">
+                {step.value.toLocaleString()}
+                {step.pct && ` (${step.pct})`}
+              </span>
+            </div>
+            <div
+              className="h-7 bg-accent rounded-md"
+              style={{
+                width: `${Math.max((step.value / maxVal) * 100, 4)}%`,
+                opacity: 1 - i * 0.25,
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/conversion-funnel.tsx
+git commit -m "feat: add ConversionFunnel component (#26)"
+```
+
+---
+
+### Task 9: CouponPerformance Component
+
+**Files:**
+- Create: `src/components/dashboard/coupon-performance.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+// src/components/dashboard/coupon-performance.tsx
+"use client";
+
+import Link from "next/link";
+
+interface CouponData {
+  id: string;
+  code: string;
+  discountType: string;
+  discountValue: number;
+  redemptions: number;
+  revenue: number;
+  active: boolean;
+}
+
+function formatDiscount(type: string, value: number): string {
+  if (type === "percentage") return `${value}% off`;
+  return `$${(value / 100).toFixed(2)} off`;
+}
+
+export function CouponPerformance({ coupons }: { coupons: CouponData[] }) {
+  if (coupons.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Coupon Performance</h3>
+        <p className="text-muted text-sm">
+          No coupons created yet.{" "}
+          <Link
+            href="/dashboard/coupons/new"
+            className="text-accent hover:underline"
+          >
+            Create one
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Coupon Performance</h3>
+      <div className="space-y-3">
+        {coupons.map((coupon) => (
+          <div
+            key={coupon.id}
+            className="flex justify-between items-center p-3 bg-paper/50 rounded-lg"
+          >
+            <div>
+              <p
+                className={`text-sm font-medium ${
+                  !coupon.active ? "line-through opacity-50" : ""
+                }`}
+              >
+                {coupon.code}
+              </p>
+              <p className="text-xs text-muted">
+                {formatDiscount(coupon.discountType, coupon.discountValue)} ·{" "}
+                {coupon.redemptions}{" "}
+                {coupon.redemptions === 1 ? "redemption" : "redemptions"}
+              </p>
+            </div>
+            <div className="text-right">
+              <p
+                className={`text-sm font-semibold ${
+                  !coupon.active ? "opacity-50" : ""
+                }`}
+              >
+                ${(coupon.revenue / 100).toFixed(2)}
+              </p>
+              <p className="text-xs text-muted">
+                {coupon.active ? "revenue" : "expired"}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/coupon-performance.tsx
+git commit -m "feat: add CouponPerformance component (#26)"
+```
+
+---
+
+## Chunk 3: Dashboard Integration
+
+### Task 10: DashboardAnalytics Orchestrator Component
+
+**Files:**
+- Create: `src/components/dashboard/dashboard-analytics.tsx`
+
+This client component ties everything together: manages period state via URL params, fetches from `/api/analytics`, and renders all widgets.
+
+- [ ] **Step 1: Create the orchestrator component**
+
+```tsx
+// src/components/dashboard/dashboard-analytics.tsx
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { PeriodSelector, type Period } from "./period-selector";
+import { KpiCards } from "./kpi-cards";
+import { RevenueChart } from "./revenue-chart";
+import { TopProducts } from "./top-products";
+import { TrafficSources } from "./traffic-sources";
+import { ConversionFunnel } from "./conversion-funnel";
+import { CouponPerformance } from "./coupon-performance";
+
+interface AnalyticsData {
+  kpis: {
+    revenue: number;
+    orders: number;
+    conversionRate: number;
+    pageViews: number;
+    changes: {
+      revenue: number | null;
+      orders: number | null;
+      conversionRate: number | null;
+      pageViews: number | null;
+    };
+  };
+  revenueOverTime: Array<{ date: string; revenue: number }>;
+  topProducts: Array<{
+    id: string;
+    title: string;
+    sales: number;
+    revenue: number;
+  }>;
+  trafficSources: Array<{
+    source: string;
+    count: number;
+    percentage: number;
+  }>;
+  conversionFunnel: {
+    pageViews: number;
+    buyIntents: number;
+    orders: number;
+  };
+  couponPerformance: Array<{
+    id: string;
+    code: string;
+    discountType: string;
+    discountValue: number;
+    redemptions: number;
+    revenue: number;
+    active: boolean;
+  }>;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="bg-surface border border-border rounded-xl p-5 animate-pulse">
+      <div className="h-3 w-20 bg-border rounded mb-3" />
+      <div className="h-7 w-28 bg-border rounded" />
+    </div>
+  );
+}
+
+function SkeletonChart({ height = "h-64" }: { height?: string }) {
+  return (
+    <div
+      className={`bg-surface border border-border rounded-xl p-6 animate-pulse ${height}`}
+    >
+      <div className="h-3 w-32 bg-border rounded mb-4" />
+      <div className="h-full bg-border/30 rounded" />
+    </div>
+  );
+}
+
+export function DashboardAnalytics() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const periodParam = searchParams.get("period");
+  const period: Period =
+    periodParam === "7d" || periodParam === "30d" || periodParam === "90d" || periodParam === "all"
+      ? periodParam
+      : "30d";
+
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (p: Period) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/analytics?period=${p}`);
+      if (!res.ok) throw new Error("Failed to load analytics");
+      const json = await res.json();
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(period);
+  }, [period, fetchData]);
+
+  const handlePeriodChange = (newPeriod: Period) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("period", newPeriod);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Period selector */}
+      <div className="flex justify-end">
+        <PeriodSelector value={period} onChange={handlePeriodChange} />
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex justify-between items-center">
+          <p className="text-red-700 text-sm">{error}</p>
+          <button
+            onClick={() => fetchData(period)}
+            className="text-red-700 text-sm font-medium underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {loading && !data && (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[...Array(4)].map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+          <SkeletonChart />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <SkeletonChart height="h-48" />
+            <SkeletonChart height="h-48" />
+          </div>
+        </>
+      )}
+
+      {/* Loaded data */}
+      {data && (
+        <>
+          <KpiCards kpis={data.kpis} />
+          <RevenueChart data={data.revenueOverTime} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <TopProducts products={data.topProducts} />
+            <TrafficSources sources={data.trafficSources} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <ConversionFunnel funnel={data.conversionFunnel} />
+            <CouponPerformance coupons={data.couponPerformance} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/dashboard/dashboard-analytics.tsx
+git commit -m "feat: add DashboardAnalytics orchestrator component (#26)"
+```
+
+---
+
+### Task 11: Integrate Analytics into Dashboard Page
+
+**Files:**
+- Modify: `src/app/(platform)/dashboard/page.tsx`
+
+Replace the static 3-card stats + quick action grid with the new `DashboardAnalytics` client component. Keep: header, Stripe CTA, recent orders, StripeToast.
+
+- [ ] **Step 1: Update the dashboard page**
+
+Replace the existing page content. The key changes:
+1. Remove the `stats` and `orderStats` queries (analytics API handles this now)
+2. Remove the `statCards` array and its rendering
+3. Remove the "Quick actions" section (products/orders/coupons links — these are in the nav)
+4. Add `<Suspense>` wrapper around `<DashboardAnalytics />`
+5. Keep: header (store name, edit/view links), StripeToast, StripeCTA, recent orders table
+
+Updated file:
+
+```tsx
+// src/app/(platform)/dashboard/page.tsx
+export const dynamic = "force-dynamic";
+
+import { Suspense } from "react";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { creators, orders } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { StripeCTA } from "@/components/stripe-cta";
+import { StripeToast } from "@/components/stripe-toast";
+import { DashboardAnalytics } from "@/components/dashboard/dashboard-analytics";
+
+export default async function DashboardPage() {
+  const session = await auth();
+  if (!session?.user?.id) redirect("/api/auth/signin");
+
+  const creator = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.userId, session.user.id))
+    .then((rows) => rows[0]);
+
+  if (!creator) redirect("/onboarding");
+
+  const stripeCheckPromise = creator.stripeConnectId
+    ? import("@/lib/stripe")
+        .then(({ getStripe }) =>
+          getStripe().accounts.retrieve(creator.stripeConnectId!)
+        )
+        .then((account) => !!account.charges_enabled)
+        .catch(() => false)
+    : Promise.resolve(false);
+
+  const [stripeReady, recentOrders] = await Promise.all([
+    stripeCheckPromise,
+    db
+      .select()
+      .from(orders)
+      .where(eq(orders.creatorId, creator.id))
+      .orderBy(desc(orders.createdAt))
+      .limit(5),
+  ]);
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-16">
+      <StripeToast />
+
+      {/* Header */}
+      <div className="flex justify-between items-start animate-fade-up">
+        <div>
+          <h1 className="text-3xl md:text-4xl font-bold">Dashboard</h1>
+          <p className="text-muted mt-1">{creator.storeName}</p>
+        </div>
+        <div className="flex gap-4 text-sm">
+          <Link
+            href="/dashboard/store"
+            className="text-muted hover:text-ink transition-colors"
+          >
+            Edit store
+          </Link>
+          <Link
+            href={`/${creator.slug}`}
+            className="text-accent font-medium hover:opacity-80 transition-opacity"
+          >
+            View store &rarr;
+          </Link>
+        </div>
+      </div>
+
+      {/* Stripe CTA */}
+      {!stripeReady && (
+        <div className="mt-8 animate-fade-up stagger-4">
+          <StripeCTA creatorId={creator.id} />
+        </div>
+      )}
+
+      {/* Analytics */}
+      <div className="mt-10">
+        <Suspense fallback={null}>
+          <DashboardAnalytics />
+        </Suspense>
+      </div>
+
+      {/* Recent orders */}
+      {recentOrders.length > 0 && (
+        <div className="mt-14 animate-fade-up stagger-5">
+          <div className="flex justify-between items-center">
+            <h2 className="text-xl font-bold">Recent Orders</h2>
+            <Link
+              href="/dashboard/orders"
+              className="text-sm text-muted hover:text-ink transition-colors"
+            >
+              View all &rarr;
+            </Link>
+          </div>
+          <div className="mt-4 border border-border rounded-xl divide-y divide-border overflow-hidden">
+            {recentOrders.map((order) => (
+              <div
+                key={order.id}
+                className="px-5 py-4 flex justify-between items-center hover:bg-paper/50 transition-colors"
+              >
+                <div>
+                  <p className="font-medium text-sm">{order.buyerEmail}</p>
+                  <p className="text-xs text-muted mt-0.5">
+                    {new Date(order.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <p className="font-semibold">
+                  ${(order.amountCents / 100).toFixed(2)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Build to verify everything compiles**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-26-dashboard-analytics
+pnpm build 2>&1 | tail -20
+```
+
+Expected: Build succeeds with `/dashboard` as dynamic route
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(platform\)/dashboard/page.tsx
+git commit -m "feat: integrate analytics widgets into dashboard page (#26)
+
+Replace static stat cards with interactive DashboardAnalytics component.
+Keeps header, Stripe CTA, and recent orders. Analytics data now served
+via /api/analytics endpoint with period selection."
+```
+
+---
+
+### Task 12: Manual Verification
+
+- [ ] **Step 1: Start dev server and verify**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-26-dashboard-analytics
+pnpm dev
+```
+
+Open http://localhost:3000/dashboard and verify:
+1. Period selector tabs work (7d/30d/90d/All)
+2. URL updates with `?period=` param
+3. KPI cards show with % changes
+4. Revenue chart renders (or "No sales yet" empty state)
+5. Top products, traffic sources, conversion funnel, coupon performance display
+6. Loading skeletons appear while fetching
+7. Responsive layout works on mobile viewport
+
+- [ ] **Step 2: Final build check**
+
+```bash
+pnpm build
+```
+
+Expected: Clean build with no errors.
+
+- [ ] **Step 3: Commit any fixes if needed, then stop dev server**

--- a/docs/superpowers/specs/2026-03-12-dashboard-analytics-design.md
+++ b/docs/superpowers/specs/2026-03-12-dashboard-analytics-design.md
@@ -1,0 +1,197 @@
+# Dashboard Analytics Design
+
+**Issue:** #26 — [GEN-013] Dashboard analytics: revenue nel tempo, top prodotti, conversion rate
+**Date:** 2026-03-12
+**Status:** Approved
+
+## Problem
+
+The creator dashboard shows only 3 static numbers (product count, order count, total revenue) and a recent orders table. Creators lack visibility into trends, product performance, traffic sources, and conversion metrics. Without analytics, serious creators migrate to more mature platforms.
+
+## Solution
+
+Enhance the existing `/dashboard` page with interactive analytics: time-series revenue chart, KPI cards with period comparisons, top products ranking, traffic source breakdown, conversion funnel (page views → buy intents → orders), and coupon performance metrics.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Location | Enhance existing `/dashboard` | Dashboard is the first thing creators see — it should be impactful. No nav overhead. |
+| Time periods | Preset tabs: 7d, 30d, 90d, All | Covers 95% of use cases without date picker complexity. |
+| Chart library | Recharts | Most popular React charting lib, declarative API, built on D3. |
+| Data freshness | API routes with aggregation queries | Real-time, clean separation, can add caching later. |
+| Scope | 5 analytics sections | Revenue over time, top products, conversion funnel, traffic sources, coupon performance. |
+
+## Dashboard Layout
+
+Top-to-bottom, single page:
+
+1. **Period selector** — tab toggle (7d / 30d / 90d / All), controls all widgets
+2. **KPI cards** (4-column grid) — Revenue, Orders, Conversion Rate, Page Views — each with % change vs previous equivalent period
+3. **Revenue over time** — Recharts AreaChart, full width, daily granularity for 7d/30d, weekly for 90d/All
+4. **Top Products + Traffic Sources** — 2-column grid
+   - Top Products: ranked list (top 5) with title, sales count, revenue
+   - Traffic Sources: horizontal bar chart showing web/MCP/API breakdown with percentages
+5. **Conversion Funnel + Coupon Performance** — 2-column grid
+   - Conversion Funnel: stepped bars (page views → buy intents → orders) with drop-off percentages
+   - Coupon Performance: list with code, discount type, redemptions, revenue generated, active/expired status
+6. **Recent Orders** — table (last 5) with "View all →" link to `/dashboard/orders`
+
+## API Design
+
+### `GET /api/analytics`
+
+Single endpoint returning all dashboard data. Authenticated, scoped to the requesting creator.
+
+**Query parameters:**
+- `period` — `7d` | `30d` | `90d` | `all` (default: `30d`)
+
+**Response shape:**
+
+```typescript
+interface AnalyticsResponse {
+  kpis: {
+    revenue: number;          // cents, creator's net (after platform fee)
+    orders: number;
+    conversionRate: number;   // percentage (0-100)
+    pageViews: number;
+    changes: {
+      revenue: number | null;        // % change vs previous period, null for "all"
+      orders: number | null;
+      conversionRate: number | null;
+      pageViews: number | null;
+    };
+  };
+  revenueOverTime: Array<{
+    date: string;             // ISO date (YYYY-MM-DD) or week start
+    revenue: number;          // cents
+  }>;
+  topProducts: Array<{
+    id: string;
+    title: string;
+    sales: number;
+    revenue: number;          // cents
+  }>;
+  trafficSources: Array<{
+    source: string;           // "web" | "mcp" | "api"
+    count: number;
+    percentage: number;
+  }>;
+  conversionFunnel: {
+    pageViews: number;
+    buyIntents: number;
+    orders: number;
+  };
+  couponPerformance: Array<{
+    id: string;
+    code: string;
+    discountType: string;     // "percentage" | "fixed"
+    discountValue: number;
+    redemptions: number;
+    revenue: number;          // cents, total revenue from orders using this coupon
+    active: boolean;
+  }>;
+}
+```
+
+### Global Rule: Revenue = Net Revenue
+
+All revenue figures throughout the API (KPIs, revenue over time, top products, coupon performance) represent the **creator's net revenue**: `amountCents - platformFeeCents`. All revenue queries filter `status = 'completed'` only.
+
+**Note:** The existing dashboard does NOT filter by `status = 'completed'`. This change makes analytics more accurate — pending/refunded orders should not count as revenue.
+
+### Page Views Join Strategy
+
+The `page_views` table has no `creatorId` column. To scope page views to a creator:
+- **Product page views** (`productId IS NOT NULL`): join `page_views` → `products` on `productId`, filter `products.creatorId = ?`
+- **Store page views** (`storeSlug IS NOT NULL`): join `page_views` → `creators` on `storeSlug = creators.slug`, filter `creators.id = ?`
+- **Traffic sources & KPI page views**: union both (product views + store views), deduplicated by `page_views.id`
+- **Conversion funnel page views**: product page views only (`productId IS NOT NULL`), since store-level visits don't have a direct buy path
+
+### Query Strategy
+
+All 6 data sections are fetched in parallel via `Promise.all`:
+
+1. **KPIs** — Two time windows (current period + previous equivalent). Revenue: `SUM(amountCents - platformFeeCents)` on completed orders. Orders: `COUNT(*)`. Page views: total (product + store views via joins above). Conversion: completed orders / product page views × 100. Changes: `(current - previous) / previous × 100`. For "All" period, `changes` values are `null`.
+
+2. **Revenue over time** — `GROUP BY DATE(createdAt)` on completed orders. Daily buckets for 7d/30d, weekly buckets for 90d/All. Returns array sorted by date ascending.
+
+3. **Top products** — Join orders with products, `GROUP BY productId`, `SUM(amountCents - platformFeeCents)` as revenue, `COUNT(*)` as sales. `ORDER BY revenue DESC LIMIT 5`. Only completed orders.
+
+4. **Traffic sources** — All creator page views (product + store), `GROUP BY source`. Includes web, mcp, api sources. Percentages computed in the query.
+
+5. **Conversion funnel** — Three parallel counts: product page views only (`productId IS NOT NULL`, joined to products for creator filter), buy_intents (filtered by `creatorId`), and completed orders (filtered by `creatorId`). All filtered by period.
+
+6. **Coupon performance** — Join orders with coupons, `GROUP BY couponId`. Sum net revenue per coupon. Include coupon metadata (code, discount type/value, active status). Only completed orders.
+
+### Auth & Security
+
+- Uses standard `auth()` → session → creator lookup pattern
+- All queries filter by `creatorId` — no cross-creator data access
+- Returns 401 if not authenticated, 404 if no creator profile
+
+## Frontend Architecture
+
+### Components
+
+All in `src/components/dashboard/`:
+
+| Component | Props | Chart Type |
+|-----------|-------|------------|
+| `PeriodSelector` | `period`, `onChange` | Tabs (no chart) |
+| `KpiCards` | `kpis` | Value + % change badge |
+| `RevenueChart` | `data` | Recharts `AreaChart` with gradient fill |
+| `TopProducts` | `products` | Ranked list |
+| `TrafficSources` | `sources` | Horizontal bars (Recharts `BarChart`) |
+| `ConversionFunnel` | `funnel` | Stepped horizontal bars |
+| `CouponPerformance` | `coupons` | List with metrics |
+
+### Data Flow
+
+1. Dashboard page remains a server component. The analytics section is a client component (`"use client"`) embedded within it.
+2. Period stored in URL search params (`?period=30d`) for shareability
+3. `useEffect` fetches `/api/analytics?period=X` on mount and period change
+4. Loading state shows skeleton/shimmer for each chart section
+5. Error state shows inline error message with retry button
+6. **Empty states per widget:** Revenue chart shows "No sales yet" with a flat line. Top products shows "No sales yet — publish a product to get started." Traffic sources shows "No visits recorded yet." Conversion funnel shows zeros. Coupon performance shows "No coupons created yet" with link to create one.
+
+### Period Comparison Logic
+
+For "% change vs previous period":
+- 7d: compare to the 7 days before that (day -14 to day -7)
+- 30d: compare to the 30 days before that (day -60 to day -30)
+- 90d: compare to the 90 days before that (day -180 to day -90)
+- All: no comparison shown (changes are `null`)
+
+### Responsive Behavior
+
+- Desktop: 4-column KPI grid, 2-column chart rows
+- Tablet: 2-column KPI grid, 2-column chart rows
+- Mobile: 1-column everything, charts stack vertically
+
+## Data Sources
+
+| Section | Tables | Key Fields |
+|---------|--------|------------|
+| Revenue/Orders KPIs | `orders` | `amountCents`, `platformFeeCents`, `createdAt`, `status` |
+| Page Views KPI | `page_views` | `createdAt`, `storeSlug` or `productId` |
+| Conversion Rate | `page_views` + `orders` | Ratio of orders to product page views |
+| Revenue over time | `orders` | `amountCents`, `platformFeeCents`, `createdAt` |
+| Top products | `orders` + `products` | Join on `productId`, group by product |
+| Traffic sources | `page_views` | `source` field (web/mcp/api) |
+| Conversion funnel | `page_views` + `buy_intents` + `orders` | Count each, filter by period |
+| Coupon performance | `orders` + `coupons` | Join on `couponId`, group by coupon |
+
+## Dependencies
+
+- **New:** `recharts` (npm package)
+- **Existing:** Drizzle ORM, Auth.js, Tailwind CSS
+
+## Out of Scope
+
+- Custom date range picker (can be added later)
+- Export analytics as CSV/PDF
+- Real-time updates (WebSocket)
+- Per-product detail analytics page
+- Goal setting / benchmarks
+- Email reports / scheduled digests

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postgres": "^3.4.8",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.0",
     "stripe": "^20.4.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@20.19.37)
@@ -1304,6 +1307,17 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1526,6 +1540,12 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@stripe/stripe-js@8.9.0':
     resolution: {integrity: sha512-OJkXvUI5GAc56QdiSRimQDvWYEqn475J+oj8RzRtFTCPtkJNO2TWW619oDY+nn1ExR+2tCVTQuRQBbR4dRugww==}
     engines: {node: '>=12.16'}
@@ -1624,6 +1644,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1643,6 +1690,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1962,6 +2012,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2006,6 +2060,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2037,6 +2135,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2239,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -2393,6 +2497,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2620,6 +2727,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2634,6 +2747,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3216,9 +3333,37 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3231,6 +3376,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3434,6 +3582,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -3525,9 +3676,17 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4801,6 +4960,18 @@ snapshots:
     dependencies:
       react: 19.2.3
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@selderee/plugin-htmlparser2@0.11.0':
@@ -5146,6 +5317,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
   '@stripe/stripe-js@8.9.0': {}
 
   '@swc/helpers@0.5.15':
@@ -5226,6 +5401,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -5243,6 +5442,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5595,6 +5796,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5630,6 +5833,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -5657,6 +5898,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -5838,6 +6081,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.45.1: {}
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
@@ -6142,6 +6387,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -6396,6 +6643,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6410,6 +6661,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -6927,7 +7180,42 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react@19.2.3: {}
+
+  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6950,6 +7238,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -7227,6 +7517,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7361,7 +7653,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   vary@1.1.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/(platform)/dashboard/page.tsx
+++ b/src/app/(platform)/dashboard/page.tsx
@@ -1,13 +1,15 @@
 export const dynamic = "force-dynamic";
 
+import { Suspense } from "react";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
-import { creators, products, orders } from "@/db/schema";
-import { eq, sql, desc } from "drizzle-orm";
+import { creators, orders } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { StripeCTA } from "@/components/stripe-cta";
 import { StripeToast } from "@/components/stripe-toast";
+import { DashboardAnalytics } from "@/components/dashboard/dashboard-analytics";
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -23,26 +25,15 @@ export default async function DashboardPage() {
 
   const stripeCheckPromise = creator.stripeConnectId
     ? import("@/lib/stripe")
-        .then(({ getStripe }) => getStripe().accounts.retrieve(creator.stripeConnectId!))
+        .then(({ getStripe }) =>
+          getStripe().accounts.retrieve(creator.stripeConnectId!)
+        )
         .then((account) => !!account.charges_enabled)
         .catch(() => false)
     : Promise.resolve(false);
 
-  const [stripeReady, [stats], [orderStats], recentOrders] = await Promise.all([
+  const [stripeReady, recentOrders] = await Promise.all([
     stripeCheckPromise,
-    db
-      .select({
-        totalProducts: sql<number>`count(distinct ${products.id})`,
-      })
-      .from(products)
-      .where(eq(products.creatorId, creator.id)),
-    db
-      .select({
-        totalOrders: sql<number>`count(*)`,
-        totalRevenue: sql<number>`coalesce(sum(${orders.amountCents} - ${orders.platformFeeCents}), 0)`,
-      })
-      .from(orders)
-      .where(eq(orders.creatorId, creator.id)),
     db
       .select()
       .from(orders)
@@ -50,15 +41,6 @@ export default async function DashboardPage() {
       .orderBy(desc(orders.createdAt))
       .limit(5),
   ]);
-
-  const statCards = [
-    { label: "Products", value: Number(stats.totalProducts) },
-    { label: "Orders", value: Number(orderStats.totalOrders) },
-    {
-      label: "Revenue",
-      value: `$${(Number(orderStats.totalRevenue) / 100).toFixed(2)}`,
-    },
-  ];
 
   return (
     <main className="max-w-5xl mx-auto px-4 py-16">
@@ -84,19 +66,6 @@ export default async function DashboardPage() {
             View store &rarr;
           </Link>
         </div>
-      </div>
-
-      {/* Stat cards */}
-      <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-6">
-        {statCards.map((stat, i) => (
-          <div
-            key={stat.label}
-            className={`bg-surface border border-border rounded-xl p-6 animate-fade-up stagger-${i + 1}`}
-          >
-            <p className="text-sm text-muted">{stat.label}</p>
-            <p className="text-3xl font-bold mt-1">{stat.value}</p>
-          </div>
-        ))}
       </div>
 
       {/* Stripe CTA */}
@@ -131,6 +100,13 @@ export default async function DashboardPage() {
             Stripe connected
           </span>
         )}
+      </div>
+
+      {/* Analytics */}
+      <div className="mt-10">
+        <Suspense fallback={null}>
+          <DashboardAnalytics />
+        </Suspense>
       </div>
 
       {/* Recent orders */}

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,0 +1,368 @@
+// src/app/api/analytics/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import {
+  orders,
+  creators,
+  products,
+  pageViews,
+  buyIntents,
+  coupons,
+} from "@/db/schema";
+import { eq, sql, and, gte, lt, isNotNull } from "drizzle-orm";
+
+type Period = "7d" | "30d" | "90d" | "all";
+
+function parsePeriod(value: string | null): Period {
+  if (value === "7d" || value === "30d" || value === "90d" || value === "all")
+    return value;
+  return "30d";
+}
+
+function periodToDays(period: Period): number | null {
+  switch (period) {
+    case "7d": return 7;
+    case "30d": return 30;
+    case "90d": return 90;
+    case "all": return null;
+  }
+}
+
+function dateRange(days: number | null): { start: Date | null; end: Date } {
+  const end = new Date();
+  if (days === null) return { start: null, end };
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  start.setHours(0, 0, 0, 0);
+  return { start, end };
+}
+
+function previousRange(days: number): { start: Date; end: Date } {
+  const end = new Date();
+  end.setDate(end.getDate() - days);
+  end.setHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setDate(start.getDate() - days);
+  return { start, end };
+}
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const creator = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.userId, session.user.id))
+    .then((rows) => rows[0]);
+
+  if (!creator) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  const period = parsePeriod(request.nextUrl.searchParams.get("period"));
+  const days = periodToDays(period);
+  const { start } = dateRange(days);
+
+  const creatorId = creator.id;
+  const creatorSlug = creator.slug;
+
+  // -- 1. KPIs (current + previous period) -------------------------------
+
+  async function queryOrderKpis(rangeStart: Date | null, rangeEnd: Date | null) {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (rangeStart) conditions.push(gte(orders.createdAt, rangeStart));
+    if (rangeEnd) conditions.push(lt(orders.createdAt, rangeEnd));
+
+    const [result] = await db
+      .select({
+        revenue: sql<number>`coalesce(sum(${orders.amountCents} - ${orders.platformFeeCents}), 0)`,
+        orderCount: sql<number>`count(*)`,
+      })
+      .from(orders)
+      .where(and(...conditions));
+
+    return {
+      revenue: Number(result.revenue),
+      orders: Number(result.orderCount),
+    };
+  }
+
+  async function queryPageViewCount(rangeStart: Date | null, rangeEnd: Date | null) {
+    const productConditions = [
+      isNotNull(pageViews.productId),
+      eq(products.creatorId, creatorId),
+    ];
+    if (rangeStart) productConditions.push(gte(pageViews.createdAt, rangeStart));
+    if (rangeEnd) productConditions.push(lt(pageViews.createdAt, rangeEnd));
+
+    const storeConditions = [
+      isNotNull(pageViews.storeSlug),
+      eq(creators.slug, creatorSlug),
+    ];
+    if (rangeStart) storeConditions.push(gte(pageViews.createdAt, rangeStart));
+    if (rangeEnd) storeConditions.push(lt(pageViews.createdAt, rangeEnd));
+
+    const [[productViews], [storeViews]] = await Promise.all([
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(pageViews)
+        .innerJoin(products, eq(pageViews.productId, products.id))
+        .where(and(...productConditions)),
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(pageViews)
+        .innerJoin(creators, eq(pageViews.storeSlug, creators.slug))
+        .where(and(...storeConditions)),
+    ]);
+
+    const productOnly = Number(productViews.count);
+    return { total: productOnly + Number(storeViews.count), productOnly };
+  }
+
+  // -- 2. Revenue over time -----------------------------------------------
+
+  async function queryRevenueOverTime() {
+    const useWeekly = period === "90d" || period === "all";
+    const dateTrunc = useWeekly ? "week" : "day";
+
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    const rows = await db
+      .select({
+        date: sql<string>`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})::date::text`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+      })
+      .from(orders)
+      .where(and(...conditions))
+      .groupBy(sql`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})`)
+      .orderBy(sql`date_trunc(${sql.raw(`'${dateTrunc}'`)}, ${orders.createdAt})`);
+
+    return rows.map((r) => ({ date: r.date, revenue: Number(r.revenue) }));
+  }
+
+  // -- 3. Top products ----------------------------------------------------
+
+  async function queryTopProducts() {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    return db
+      .select({
+        id: products.id,
+        title: products.title,
+        sales: sql<number>`count(*)`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+      })
+      .from(orders)
+      .innerJoin(products, eq(orders.productId, products.id))
+      .where(and(...conditions))
+      .groupBy(products.id, products.title)
+      .orderBy(sql`sum(${orders.amountCents} - ${orders.platformFeeCents}) desc`)
+      .limit(5)
+      .then((rows) =>
+        rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          sales: Number(r.sales),
+          revenue: Number(r.revenue),
+        }))
+      );
+  }
+
+  // -- 4. Traffic sources -------------------------------------------------
+
+  async function queryTrafficSources() {
+    const productConditions = [
+      isNotNull(pageViews.productId),
+      eq(products.creatorId, creatorId),
+    ];
+    if (start) productConditions.push(gte(pageViews.createdAt, start));
+
+    const storeConditions = [
+      isNotNull(pageViews.storeSlug),
+      eq(creators.slug, creatorSlug),
+    ];
+    if (start) storeConditions.push(gte(pageViews.createdAt, start));
+
+    const [productBySource, storeBySource] = await Promise.all([
+      db
+        .select({
+          source: pageViews.source,
+          count: sql<number>`count(*)`,
+        })
+        .from(pageViews)
+        .innerJoin(products, eq(pageViews.productId, products.id))
+        .where(and(...productConditions))
+        .groupBy(pageViews.source),
+      db
+        .select({
+          source: pageViews.source,
+          count: sql<number>`count(*)`,
+        })
+        .from(pageViews)
+        .innerJoin(creators, eq(pageViews.storeSlug, creators.slug))
+        .where(and(...storeConditions))
+        .groupBy(pageViews.source),
+    ]);
+
+    const merged = new Map<string, number>();
+    for (const row of [...productBySource, ...storeBySource]) {
+      merged.set(row.source, (merged.get(row.source) ?? 0) + Number(row.count));
+    }
+
+    const total = Array.from(merged.values()).reduce((a, b) => a + b, 0);
+    return Array.from(merged.entries())
+      .map(([source, count]) => ({
+        source,
+        count,
+        percentage: total > 0 ? Math.round((count / total) * 1000) / 10 : 0,
+      }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // -- 5. Buy intent count ------------------------------------------------
+
+  async function queryBuyIntentCount() {
+    const conditions = [eq(buyIntents.creatorId, creatorId)];
+    if (start) conditions.push(gte(buyIntents.createdAt, start));
+    const [result] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(buyIntents)
+      .where(and(...conditions));
+    return Number(result.count);
+  }
+
+  // -- 6. Coupon performance -----------------------------------------------
+
+  async function queryCouponPerformance() {
+    const conditions = [
+      eq(orders.creatorId, creatorId),
+      eq(orders.status, "completed"),
+      isNotNull(orders.couponId),
+    ];
+    if (start) conditions.push(gte(orders.createdAt, start));
+
+    const rows = await db
+      .select({
+        id: coupons.id,
+        code: coupons.code,
+        discountType: coupons.discountType,
+        discountValue: coupons.discountValue,
+        redemptions: sql<number>`count(*)`,
+        revenue: sql<number>`sum(${orders.amountCents} - ${orders.platformFeeCents})`,
+        active: coupons.active,
+      })
+      .from(orders)
+      .innerJoin(coupons, eq(orders.couponId, coupons.id))
+      .where(and(...conditions))
+      .groupBy(
+        coupons.id,
+        coupons.code,
+        coupons.discountType,
+        coupons.discountValue,
+        coupons.active
+      );
+
+    return rows.map((r) => ({
+      id: r.id,
+      code: r.code,
+      discountType: r.discountType,
+      discountValue: r.discountValue,
+      redemptions: Number(r.redemptions),
+      revenue: Number(r.revenue),
+      active: r.active,
+    }));
+  }
+
+  // -- Execute all in parallel ---------------------------------------------
+
+  const currentKpis = queryOrderKpis(start, null);
+  const currentPageViews = queryPageViewCount(start, null);
+
+  let previousKpis: Promise<{ revenue: number; orders: number }>;
+  let previousPageViews: Promise<{ total: number; productOnly: number }>;
+
+  if (days !== null) {
+    const prev = previousRange(days);
+    previousKpis = queryOrderKpis(prev.start, prev.end);
+    previousPageViews = queryPageViewCount(prev.start, prev.end);
+  } else {
+    previousKpis = Promise.resolve({ revenue: 0, orders: 0 });
+    previousPageViews = Promise.resolve({ total: 0, productOnly: 0 });
+  }
+
+  const [
+    curKpis,
+    curPV,
+    prevKpis,
+    prevPV,
+    revenueOverTime,
+    topProducts,
+    trafficSources,
+    couponPerformance,
+    buyIntentCount,
+  ] = await Promise.all([
+    currentKpis,
+    currentPageViews,
+    previousKpis,
+    previousPageViews,
+    queryRevenueOverTime(),
+    queryTopProducts(),
+    queryTrafficSources(),
+    queryCouponPerformance(),
+    queryBuyIntentCount(),
+  ]);
+
+  const conversionFunnel = {
+    pageViews: curPV.productOnly,
+    buyIntents: buyIntentCount,
+    orders: curKpis.orders,
+  };
+
+  const conversionRate = curPV.productOnly > 0
+    ? Math.round((curKpis.orders / curPV.productOnly) * 1000) / 10
+    : 0;
+  const prevConversionRate = prevPV.productOnly > 0
+    ? Math.round((prevKpis.orders / prevPV.productOnly) * 1000) / 10
+    : 0;
+
+  function pctChange(current: number, previous: number): number | null {
+    if (days === null) return null;
+    if (previous === 0) return current > 0 ? 100 : 0;
+    return Math.round(((current - previous) / previous) * 1000) / 10;
+  }
+
+  return NextResponse.json({
+    kpis: {
+      revenue: curKpis.revenue,
+      orders: curKpis.orders,
+      conversionRate,
+      pageViews: curPV.total,
+      changes: {
+        revenue: pctChange(curKpis.revenue, prevKpis.revenue),
+        orders: pctChange(curKpis.orders, prevKpis.orders),
+        conversionRate: pctChange(conversionRate, prevConversionRate),
+        pageViews: pctChange(curPV.total, prevPV.total),
+      },
+    },
+    revenueOverTime,
+    topProducts,
+    trafficSources,
+    conversionFunnel,
+    couponPerformance,
+  });
+}

--- a/src/components/dashboard/conversion-funnel.tsx
+++ b/src/components/dashboard/conversion-funnel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+interface FunnelData {
+  pageViews: number;
+  buyIntents: number;
+  orders: number;
+}
+
+export function ConversionFunnel({ funnel }: { funnel: FunnelData }) {
+  const maxVal = Math.max(funnel.pageViews, 1);
+
+  const steps = [
+    {
+      label: "Page Views",
+      value: funnel.pageViews,
+      pct: null as string | null,
+    },
+    {
+      label: "Buy Intent (clicked Buy)",
+      value: funnel.buyIntents,
+      pct:
+        funnel.pageViews > 0
+          ? `${((funnel.buyIntents / funnel.pageViews) * 100).toFixed(1)}%`
+          : "0%",
+    },
+    {
+      label: "Completed Orders",
+      value: funnel.orders,
+      pct:
+        funnel.pageViews > 0
+          ? `${((funnel.orders / funnel.pageViews) * 100).toFixed(1)}%`
+          : "0%",
+    },
+  ];
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Conversion Funnel</h3>
+      <div className="space-y-3">
+        {steps.map((step, i) => (
+          <div key={step.label}>
+            <div className="flex justify-between text-xs mb-1">
+              <span>{step.label}</span>
+              <span className="text-muted">
+                {step.value.toLocaleString()}
+                {step.pct && ` (${step.pct})`}
+              </span>
+            </div>
+            <div
+              className="h-7 bg-accent rounded-md"
+              style={{
+                width: `${Math.max((step.value / maxVal) * 100, 4)}%`,
+                opacity: 1 - i * 0.25,
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/coupon-performance.tsx
+++ b/src/components/dashboard/coupon-performance.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+
+interface CouponData {
+  id: string;
+  code: string;
+  discountType: string;
+  discountValue: number;
+  redemptions: number;
+  revenue: number;
+  active: boolean;
+}
+
+function formatDiscount(type: string, value: number): string {
+  if (type === "percentage") return `${value}% off`;
+  return `$${(value / 100).toFixed(2)} off`;
+}
+
+export function CouponPerformance({ coupons }: { coupons: CouponData[] }) {
+  if (coupons.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Coupon Performance</h3>
+        <p className="text-muted text-sm">
+          No coupons created yet.{" "}
+          <Link
+            href="/dashboard/coupons/new"
+            className="text-accent hover:underline"
+          >
+            Create one
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Coupon Performance</h3>
+      <div className="space-y-3">
+        {coupons.map((coupon) => (
+          <div
+            key={coupon.id}
+            className="flex justify-between items-center p-3 bg-paper/50 rounded-lg"
+          >
+            <div>
+              <p
+                className={`text-sm font-medium ${
+                  !coupon.active ? "line-through opacity-50" : ""
+                }`}
+              >
+                {coupon.code}
+              </p>
+              <p className="text-xs text-muted">
+                {formatDiscount(coupon.discountType, coupon.discountValue)} ·{" "}
+                {coupon.redemptions}{" "}
+                {coupon.redemptions === 1 ? "redemption" : "redemptions"}
+              </p>
+            </div>
+            <div className="text-right">
+              <p
+                className={`text-sm font-semibold ${
+                  !coupon.active ? "opacity-50" : ""
+                }`}
+              >
+                ${(coupon.revenue / 100).toFixed(2)}
+              </p>
+              <p className="text-xs text-muted">
+                {coupon.active ? "revenue" : "inactive"}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/dashboard-analytics.tsx
+++ b/src/components/dashboard/dashboard-analytics.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { PeriodSelector, type Period } from "./period-selector";
+import { KpiCards } from "./kpi-cards";
+import { RevenueChart } from "./revenue-chart";
+import { TopProducts } from "./top-products";
+import { TrafficSources } from "./traffic-sources";
+import { ConversionFunnel } from "./conversion-funnel";
+import { CouponPerformance } from "./coupon-performance";
+
+interface AnalyticsData {
+  kpis: {
+    revenue: number;
+    orders: number;
+    conversionRate: number;
+    pageViews: number;
+    changes: {
+      revenue: number | null;
+      orders: number | null;
+      conversionRate: number | null;
+      pageViews: number | null;
+    };
+  };
+  revenueOverTime: Array<{ date: string; revenue: number }>;
+  topProducts: Array<{
+    id: string;
+    title: string;
+    sales: number;
+    revenue: number;
+  }>;
+  trafficSources: Array<{
+    source: string;
+    count: number;
+    percentage: number;
+  }>;
+  conversionFunnel: {
+    pageViews: number;
+    buyIntents: number;
+    orders: number;
+  };
+  couponPerformance: Array<{
+    id: string;
+    code: string;
+    discountType: string;
+    discountValue: number;
+    redemptions: number;
+    revenue: number;
+    active: boolean;
+  }>;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="bg-surface border border-border rounded-xl p-5 animate-pulse">
+      <div className="h-3 w-20 bg-border rounded mb-3" />
+      <div className="h-7 w-28 bg-border rounded" />
+    </div>
+  );
+}
+
+function SkeletonChart({ height = "h-64" }: { height?: string }) {
+  return (
+    <div
+      className={`bg-surface border border-border rounded-xl p-6 animate-pulse ${height}`}
+    >
+      <div className="h-3 w-32 bg-border rounded mb-4" />
+      <div className="h-full bg-border/30 rounded" />
+    </div>
+  );
+}
+
+export function DashboardAnalytics() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const periodParam = searchParams.get("period");
+  const period: Period =
+    periodParam === "7d" || periodParam === "30d" || periodParam === "90d" || periodParam === "all"
+      ? periodParam
+      : "30d";
+
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (p: Period, signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/analytics?period=${p}`, { signal });
+      if (!res.ok) throw new Error("Failed to load analytics");
+      const json = await res.json();
+      setData(json);
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchData(period, controller.signal);
+    return () => controller.abort();
+  }, [period, fetchData]);
+
+  const handlePeriodChange = (newPeriod: Period) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("period", newPeriod);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Period selector */}
+      <div className="flex justify-end">
+        <PeriodSelector value={period} onChange={handlePeriodChange} />
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex justify-between items-center">
+          <p className="text-red-700 text-sm">{error}</p>
+          <button
+            onClick={() => fetchData(period)}
+            className="text-red-700 text-sm font-medium underline"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {loading && !data && (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[...Array(4)].map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+          <SkeletonChart />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <SkeletonChart height="h-48" />
+            <SkeletonChart height="h-48" />
+          </div>
+        </>
+      )}
+
+      {/* Loaded data */}
+      {data && (
+        <>
+          <KpiCards kpis={data.kpis} />
+          <RevenueChart data={data.revenueOverTime} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <TopProducts products={data.topProducts} />
+            <TrafficSources sources={data.trafficSources} />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <ConversionFunnel funnel={data.conversionFunnel} />
+            <CouponPerformance coupons={data.couponPerformance} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+interface KpiData {
+  revenue: number;
+  orders: number;
+  conversionRate: number;
+  pageViews: number;
+  changes: {
+    revenue: number | null;
+    orders: number | null;
+    conversionRate: number | null;
+    pageViews: number | null;
+  };
+}
+
+function formatCurrency(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatChange(value: number | null): { text: string; color: string } | null {
+  if (value === null) return null;
+  const sign = value > 0 ? "+" : "";
+  const color = value > 0 ? "text-green-600" : value < 0 ? "text-red-500" : "text-muted";
+  return { text: `${sign}${value}%`, color };
+}
+
+export function KpiCards({ kpis }: { kpis: KpiData }) {
+  const cards = [
+    { label: "Revenue", value: formatCurrency(kpis.revenue), change: kpis.changes.revenue },
+    { label: "Orders", value: kpis.orders.toLocaleString(), change: kpis.changes.orders },
+    { label: "Conversion Rate", value: `${kpis.conversionRate}%`, change: kpis.changes.conversionRate },
+    { label: "Page Views", value: kpis.pageViews.toLocaleString(), change: kpis.changes.pageViews },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => {
+        const change = formatChange(card.change);
+        return (
+          <div
+            key={card.label}
+            className="bg-surface border border-border rounded-xl p-5"
+          >
+            <p className="text-sm text-muted">{card.label}</p>
+            <p className="text-2xl font-bold mt-1">{card.value}</p>
+            {change && (
+              <p className={`text-xs mt-1 ${change.color}`}>
+                {change.text} vs prev
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/dashboard/period-selector.tsx
+++ b/src/components/dashboard/period-selector.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+const PERIODS = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+  { value: "all", label: "All" },
+] as const;
+
+export type Period = (typeof PERIODS)[number]["value"];
+
+export function PeriodSelector({
+  value,
+  onChange,
+}: {
+  value: Period;
+  onChange: (period: Period) => void;
+}) {
+  return (
+    <div className="flex gap-1 bg-surface border border-border rounded-lg p-1">
+      {PERIODS.map((p) => (
+        <button
+          key={p.value}
+          onClick={() => onChange(p.value)}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            value === p.value
+              ? "bg-accent text-white"
+              : "text-muted hover:text-ink"
+          }`}
+        >
+          {p.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dashboard/revenue-chart.tsx
+++ b/src/components/dashboard/revenue-chart.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface DataPoint {
+  date: string;
+  revenue: number;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatCurrency(cents: number): string {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+export function RevenueChart({ data }: { data: DataPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Revenue Over Time</h3>
+        <div className="flex items-center justify-center h-48 text-muted text-sm">
+          No sales yet
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Revenue Over Time</h3>
+      <ResponsiveContainer width="100%" height={240}>
+        <AreaChart data={data}>
+          <defs>
+            <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity={0.3} />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity={0.02} />
+            </linearGradient>
+          </defs>
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatDate}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted)", fontSize: 12 }}
+          />
+          <YAxis
+            tickFormatter={formatCurrency}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted)", fontSize: 12 }}
+            width={60}
+          />
+          <Tooltip
+            formatter={(value) => [formatCurrency(Number(value)), "Revenue"]}
+            labelFormatter={(label) => formatDate(String(label))}
+            contentStyle={{
+              backgroundColor: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: "8px",
+              fontSize: "13px",
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="revenue"
+            stroke="var(--accent)"
+            strokeWidth={2}
+            fill="url(#revenueGradient)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/dashboard/top-products.tsx
+++ b/src/components/dashboard/top-products.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+interface Product {
+  id: string;
+  title: string;
+  sales: number;
+  revenue: number;
+}
+
+export function TopProducts({ products }: { products: Product[] }) {
+  if (products.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Top Products</h3>
+        <p className="text-muted text-sm">
+          No sales yet — publish a product to get started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Top Products</h3>
+      <div className="space-y-4">
+        {products.map((product) => (
+          <div key={product.id} className="flex justify-between items-center">
+            <div>
+              <p className="text-sm font-medium">{product.title}</p>
+              <p className="text-xs text-muted">
+                {product.sales} {product.sales === 1 ? "sale" : "sales"}
+              </p>
+            </div>
+            <p className="text-sm font-semibold">
+              ${(product.revenue / 100).toFixed(2)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/traffic-sources.tsx
+++ b/src/components/dashboard/traffic-sources.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+interface SourceData {
+  source: string;
+  count: number;
+  percentage: number;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  web: "Web",
+  mcp: "MCP (AI Agents)",
+  api: "API",
+};
+
+const SOURCE_COLORS: Record<string, string> = {
+  web: "bg-accent",
+  mcp: "bg-purple-500",
+  api: "bg-green-500",
+};
+
+export function TrafficSources({ sources }: { sources: SourceData[] }) {
+  if (sources.length === 0) {
+    return (
+      <div className="bg-surface border border-border rounded-xl p-6">
+        <h3 className="text-sm font-semibold mb-4">Traffic Sources</h3>
+        <p className="text-muted text-sm">No visits recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-surface border border-border rounded-xl p-6">
+      <h3 className="text-sm font-semibold mb-4">Traffic Sources</h3>
+      <div className="space-y-4">
+        {sources.map((s) => (
+          <div key={s.source}>
+            <div className="flex justify-between text-xs mb-1">
+              <span>{SOURCE_LABELS[s.source] ?? s.source}</span>
+              <span className="text-muted">
+                {s.count.toLocaleString()} ({s.percentage}%)
+              </span>
+            </div>
+            <div className="h-2 bg-border rounded-full">
+              <div
+                className={`h-full rounded-full ${SOURCE_COLORS[s.source] ?? "bg-accent"}`}
+                style={{ width: `${Math.max(s.percentage, 2)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #26

## Summary
- Full analytics dashboard replacing the 3 static stat cards
- KPI cards with period comparison (7d/30d/90d/all): revenue, orders, conversion rate, page views
- Revenue over time chart (Recharts AreaChart, daily/weekly aggregation)
- Top 5 products by revenue
- Traffic source breakdown (web/mcp/api)
- Conversion funnel (page views → buy intents → orders)
- Coupon performance metrics
- New `/api/analytics` endpoint with parallel DB queries

## Test plan
- [ ] Verify dashboard loads with period selector defaulting to 30d
- [ ] Switch periods — data updates, no stale responses
- [ ] Empty state displays correctly for new creators
- [ ] KPI change percentages show correct direction
- [ ] Revenue chart renders with correct date formatting
- [ ] Coupon performance shows active/inactive states