### PR TITLE
Admin API keys for external integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "eslint",
     "seed": "tsx src/scripts/seed.ts",
-    "smoke": "vitest run --config vitest.config.smoke.ts"
+    "smoke": "vitest run --config vitest.config.smoke.ts",
+    "generate-api-key": "tsx src/scripts/generate-api-key.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/src/app/api/admin/coupons/route.ts
+++ b/src/app/api/admin/coupons/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateApiKey, hasScope, insufficientScope } from "@/lib/api-key";
+import { db } from "@/db";
+import { coupons, creators, products } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { generateCouponCode } from "@/lib/coupon";
+
+const READ_SCOPE = "admin:read:orders";
+const WRITE_SCOPE = "admin:write:coupons";
+
+export async function GET(req: NextRequest) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, READ_SCOPE)) return insufficientScope(READ_SCOPE);
+
+  const rows = await db
+    .select({
+      coupon: coupons,
+      creatorName: creators.name,
+    })
+    .from(coupons)
+    .innerJoin(creators, eq(coupons.creatorId, creators.id));
+
+  return NextResponse.json(rows);
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, WRITE_SCOPE)) return insufficientScope(WRITE_SCOPE);
+
+  const body = await req.json();
+  const { creatorId, code, discountType, discountValue, productId, maxRedemptions, expiresAt } = body;
+
+  if (!creatorId || !discountType || discountValue === undefined) {
+    return NextResponse.json(
+      { error: "creatorId, discountType, and discountValue are required" },
+      { status: 400 }
+    );
+  }
+
+  // Verify creator exists
+  const [creator] = await db
+    .select({ id: creators.id })
+    .from(creators)
+    .where(eq(creators.id, creatorId));
+
+  if (!creator) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  // Verify product belongs to creator (if provided)
+  if (productId) {
+    const [product] = await db
+      .select({ id: products.id })
+      .from(products)
+      .where(and(eq(products.id, productId), eq(products.creatorId, creatorId)));
+
+    if (!product) {
+      return NextResponse.json({ error: "Product not found for this creator" }, { status: 404 });
+    }
+  }
+
+  const finalCode = (code || generateCouponCode()).toUpperCase().trim();
+
+  try {
+    const [coupon] = await db
+      .insert(coupons)
+      .values({
+        creatorId,
+        code: finalCode,
+        discountType,
+        discountValue,
+        productId: productId || null,
+        maxRedemptions: maxRedemptions || null,
+        expiresAt: expiresAt ? new Date(expiresAt) : null,
+      })
+      .returning();
+
+    return NextResponse.json(coupon, { status: 201 });
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("unique")) {
+      return NextResponse.json(
+        { error: "A coupon with this code already exists for this creator" },
+        { status: 409 }
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/creators/[id]/route.ts
+++ b/src/app/api/admin/creators/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateApiKey, hasScope, insufficientScope } from "@/lib/api-key";
+import { db } from "@/db";
+import { creators } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+const SCOPE = "admin:write:creators";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, "admin:read:creators")) {
+    return insufficientScope("admin:read:creators");
+  }
+
+  const { id } = await params;
+  const [creator] = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.id, id));
+
+  if (!creator) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(creator);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, SCOPE)) return insufficientScope(SCOPE);
+
+  const { id } = await params;
+  const body = await req.json();
+
+  const allowedFields: Record<string, unknown> = {};
+  if (body.name !== undefined) allowedFields.name = body.name;
+  if (body.email !== undefined) allowedFields.email = body.email;
+  if (body.storeName !== undefined) allowedFields.storeName = body.storeName;
+  if (body.storeDescription !== undefined)
+    allowedFields.storeDescription = body.storeDescription;
+
+  if (Object.keys(allowedFields).length === 0) {
+    return NextResponse.json(
+      { error: "No valid fields to update" },
+      { status: 400 }
+    );
+  }
+
+  const [updated] = await db
+    .update(creators)
+    .set(allowedFields)
+    .where(eq(creators.id, id))
+    .returning();
+
+  if (!updated) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/admin/creators/route.ts
+++ b/src/app/api/admin/creators/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateApiKey, hasScope, insufficientScope } from "@/lib/api-key";
+import { db } from "@/db";
+import { creators } from "@/db/schema";
+import { sql } from "drizzle-orm";
+
+const SCOPE = "admin:read:creators";
+
+export async function GET(req: NextRequest) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, SCOPE)) return insufficientScope(SCOPE);
+
+  const rows = await db
+    .select({
+      id: creators.id,
+      userId: creators.userId,
+      email: creators.email,
+      name: creators.name,
+      slug: creators.slug,
+      storeName: creators.storeName,
+      stripeConnectId: creators.stripeConnectId,
+      createdAt: creators.createdAt,
+      productCount: sql<number>`(
+        select count(*) from products where products.creator_id = creators.id
+      )`,
+      orderCount: sql<number>`(
+        select count(*) from orders where orders.creator_id = creators.id and orders.status = 'completed'
+      )`,
+      revenueCents: sql<number>`(
+        select coalesce(sum(orders.amount_cents), 0) from orders where orders.creator_id = creators.id and orders.status = 'completed'
+      )`,
+    })
+    .from(creators);
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateApiKey, hasScope, insufficientScope } from "@/lib/api-key";
+import { db } from "@/db";
+import { orders, products, creators } from "@/db/schema";
+import { eq, gte, desc } from "drizzle-orm";
+
+const SCOPE = "admin:read:orders";
+
+export async function GET(req: NextRequest) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, SCOPE)) return insufficientScope(SCOPE);
+
+  const since = req.nextUrl.searchParams.get("since");
+  const limit = Math.min(
+    parseInt(req.nextUrl.searchParams.get("limit") ?? "100", 10),
+    500
+  );
+
+  const conditions = [];
+  if (since) {
+    conditions.push(gte(orders.createdAt, new Date(since)));
+  }
+
+  const rows = await db
+    .select({
+      id: orders.id,
+      productId: orders.productId,
+      productTitle: products.title,
+      creatorId: orders.creatorId,
+      creatorName: creators.name,
+      creatorEmail: creators.email,
+      buyerEmail: orders.buyerEmail,
+      buyerName: orders.buyerName,
+      amountCents: orders.amountCents,
+      platformFeeCents: orders.platformFeeCents,
+      status: orders.status,
+      couponId: orders.couponId,
+      createdAt: orders.createdAt,
+    })
+    .from(orders)
+    .innerJoin(products, eq(orders.productId, products.id))
+    .innerJoin(creators, eq(orders.creatorId, creators.id))
+    .where(conditions.length > 0 ? conditions[0] : undefined)
+    .orderBy(desc(orders.createdAt))
+    .limit(limit);
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateApiKey, hasScope, insufficientScope } from "@/lib/api-key";
+import { db } from "@/db";
+import { products, creators } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+
+const SCOPE = "admin:read:products";
+
+export async function GET(req: NextRequest) {
+  const auth = await validateApiKey(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!hasScope(auth, SCOPE)) return insufficientScope(SCOPE);
+
+  const limit = Math.min(
+    parseInt(req.nextUrl.searchParams.get("limit") ?? "100", 10),
+    500
+  );
+
+  const rows = await db
+    .select({
+      id: products.id,
+      creatorId: products.creatorId,
+      creatorName: creators.name,
+      title: products.title,
+      slug: products.slug,
+      description: products.description,
+      priceCents: products.priceCents,
+      currency: products.currency,
+      category: products.category,
+      status: products.status,
+      createdAt: products.createdAt,
+    })
+    .from(products)
+    .innerJoin(creators, eq(products.creatorId, creators.id))
+    .orderBy(desc(products.createdAt))
+    .limit(limit);
+
+  return NextResponse.json(rows);
+}

--- a/src/components/dashboard/conversion-funnel.tsx
+++ b/src/components/dashboard/conversion-funnel.tsx
@@ -7,7 +7,7 @@ interface FunnelData {
 }
 
 export function ConversionFunnel({ funnel }: { funnel: FunnelData }) {
-  const maxVal = Math.max(funnel.pageViews, 1);
+  const maxVal = Math.max(funnel.pageViews, funnel.buyIntents, funnel.orders, 1);
 
   const steps = [
     {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -283,3 +283,17 @@ export const referralConversions = pgTable("referral_conversions", {
     .defaultNow()
     .notNull(),
 });
+
+export const apiKeys = pgTable("api_keys", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  creatorId: uuid("creator_id").references(() => creators.id),
+  keyHash: text("key_hash").notNull(),
+  keyPrefix: text("key_prefix").notNull(),
+  name: text("name").notNull(),
+  scopes: text("scopes").array().notNull(),
+  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  expiresAt: timestamp("expires_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -1,0 +1,72 @@
+import { createHash } from "crypto";
+import { db } from "@/db";
+import { apiKeys } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+export function hashApiKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+export function generateApiKey(): { key: string; prefix: string; hash: string } {
+  const key = `fsk_${crypto.randomUUID().replace(/-/g, "")}`;
+  const prefix = key.slice(0, 12);
+  const hash = hashApiKey(key);
+  return { key, prefix, hash };
+}
+
+export type ApiKeyAuth = {
+  type: "api_key";
+  keyId: string;
+  scopes: string[];
+  creatorId: string | null;
+};
+
+export type SessionAuth = {
+  type: "session";
+  userId: string;
+};
+
+export type AuthResult = ApiKeyAuth | SessionAuth | null;
+
+export async function validateApiKey(
+  req: NextRequest
+): Promise<ApiKeyAuth | null> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer fsk_")) return null;
+
+  const key = authHeader.slice(7); // Remove "Bearer "
+  const hash = hashApiKey(key);
+
+  const [record] = await db
+    .select()
+    .from(apiKeys)
+    .where(eq(apiKeys.keyHash, hash));
+
+  if (!record) return null;
+  if (record.expiresAt && record.expiresAt < new Date()) return null;
+
+  // Update last_used_at (fire-and-forget)
+  db.update(apiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(apiKeys.id, record.id))
+    .then(() => {});
+
+  return {
+    type: "api_key",
+    keyId: record.id,
+    scopes: record.scopes,
+    creatorId: record.creatorId,
+  };
+}
+
+export function hasScope(auth: ApiKeyAuth, scope: string): boolean {
+  return auth.scopes.includes(scope) || auth.scopes.includes("admin:*");
+}
+
+export function insufficientScope(scope: string) {
+  return NextResponse.json(
+    { error: "Insufficient scope", required: scope },
+    { status: 403 }
+  );
+}

--- a/src/scripts/generate-api-key.ts
+++ b/src/scripts/generate-api-key.ts
@@ -1,0 +1,42 @@
+import "dotenv/config";
+import { db } from "../db";
+import { apiKeys } from "../db/schema";
+import { generateApiKey } from "../lib/api-key";
+
+const ADMIN_SCOPES = [
+  "admin:read:creators",
+  "admin:read:orders",
+  "admin:read:products",
+  "admin:read:analytics",
+  "admin:write:creators",
+  "admin:write:coupons",
+];
+
+async function main() {
+  const name = process.argv[2] || "HubSpot CRM";
+
+  const { key, prefix, hash } = generateApiKey();
+
+  await db.insert(apiKeys).values({
+    name,
+    keyHash: hash,
+    keyPrefix: prefix,
+    scopes: ADMIN_SCOPES,
+    creatorId: null,
+  });
+
+  console.log("API key created successfully!");
+  console.log(`  Name:   ${name}`);
+  console.log(`  Key:    ${key}`);
+  console.log(`  Prefix: ${prefix}`);
+  console.log(`  Scopes: ${ADMIN_SCOPES.join(", ")}`);
+  console.log("");
+  console.log("Save this key now - it cannot be retrieved later.");
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Scoped API key authentication for platform admin access (HubSpot CRM connector)
- Admin API routes: creators, orders, products, coupons (read + write)
- Key generation: `pnpm generate-api-key "HubSpot CRM"`

## Test plan
- [x] `pnpm build` passes
- [ ] `pnpm drizzle-kit push` on production DB
- [ ] Generate key and configure in HubSpot