### PR TITLE
[Issue #43] Pagine legal: Terms of Service e Privacy Policy

### DIFF
--- a/docs/superpowers/plans/2026-03-14-legal-pages.md
+++ b/docs/superpowers/plans/2026-03-14-legal-pages.md
@@ -1,0 +1,859 @@
+# Legal Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create Terms of Service and Privacy Policy pages with EN/IT toggle and shared footer for Stripe Connect compliance.
+
+**Architecture:** Content-as-data in `lib/legal-content.ts`, shared `<LegalPage>` client component with language toggle, thin server-component page wrappers exporting metadata. Shared `<Footer>` added to platform layout; store page inline footers updated with legal links.
+
+**Tech Stack:** Next.js App Router, TypeScript, Tailwind CSS
+
+**Spec:** `docs/superpowers/specs/2026-03-14-legal-pages-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/lib/legal-content.ts` | Create | Types + all EN/IT legal text for ToS and Privacy |
+| `src/components/language-toggle.tsx` | Create | Client component: EN/IT pill toggle |
+| `src/components/legal-page.tsx` | Create | Client component: renders legal document with toggle |
+| `src/app/(platform)/legal/terms/page.tsx` | Create | Server component: metadata + renders LegalPage with termsContent |
+| `src/app/(platform)/legal/privacy/page.tsx` | Create | Server component: metadata + renders LegalPage with privacyContent |
+| `src/components/footer.tsx` | Create | Server component: shared footer with legal links |
+| `src/app/(platform)/layout.tsx` | Modify | Add `<Footer />` after `{children}` |
+| `src/app/(platform)/page.tsx` | Modify | Remove inline footer (lines 87-90) |
+| `src/app/[slug]/page.tsx` | Modify | Add legal links to inline footer (line 309-311) |
+| `src/app/[slug]/[productSlug]/page.tsx` | Modify | Add legal links to inline footer (line 137-143) |
+| `src/app/sitemap.ts` | Modify | Add `/legal/terms` and `/legal/privacy` entries |
+
+---
+
+## Task 1: Legal Content Data
+
+**Files:**
+- Create: `src/lib/legal-content.ts`
+
+This file contains all legal text as structured TypeScript objects. It has no dependencies and everything else depends on it.
+
+- [ ] **Step 1: Create `src/lib/legal-content.ts` with types and Terms of Service content (EN + IT)**
+
+```typescript
+export type LegalSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+export type LegalDocument = {
+  title: string;
+  lastUpdated: string;
+  sections: LegalSection[];
+};
+
+export type BilingualLegalDocument = {
+  en: LegalDocument;
+  it: LegalDocument;
+};
+
+export const termsContent: BilingualLegalDocument = {
+  en: {
+    title: "Terms of Service",
+    lastUpdated: "March 14, 2026",
+    sections: [
+      {
+        heading: "1. Acceptance of Terms",
+        paragraphs: [
+          "By accessing or using Fooshop (\"the Platform\"), operated by Fooshop (\"we\", \"us\", \"our\"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Platform.",
+          "We reserve the right to update these terms at any time. Continued use of the Platform after changes constitutes acceptance of the revised terms."
+        ]
+      },
+      {
+        heading: "2. Platform Description",
+        paragraphs: [
+          "Fooshop is an AI-powered marketplace for digital products. Creators can sell digital goods including ebooks, templates, courses, presets, prompts, and other digital assets. The Platform provides AI-generated storefronts, payment processing, and product discovery services."
+        ]
+      },
+      {
+        heading: "3. Creator Accounts & Obligations",
+        paragraphs: [
+          "To sell on Fooshop, you must create a creator account and connect a Stripe account for payment processing. You must be at least 18 years old and legally able to enter into contracts.",
+          "As a creator, you are responsible for: the accuracy of your product listings, the quality and legality of your digital products, complying with all applicable laws and regulations, and responding to buyer inquiries in a timely manner.",
+          "You must not sell products that infringe on intellectual property rights, contain malware or harmful code, or violate any applicable laws."
+        ]
+      },
+      {
+        heading: "4. Buyer Rights & Digital Products",
+        paragraphs: [
+          "When you purchase a digital product on Fooshop, you receive a license to use that product as described in the product listing. Unless explicitly stated otherwise, this is a personal, non-transferable, non-exclusive license.",
+          "Due to the nature of digital products, all sales are final. Refunds may be issued at the discretion of the creator or Fooshop in cases of technical issues preventing product delivery."
+        ]
+      },
+      {
+        heading: "5. Pricing, Commissions & Payments",
+        paragraphs: [
+          "Fooshop charges a 5% commission on each sale. There are no subscription fees, listing fees, or other hidden costs. Creators receive 95% of each sale amount.",
+          "Payments are processed through Stripe Connect. Creators are paid directly to their connected Stripe account. Fooshop does not hold or manage creator funds beyond the commission amount.",
+          "All prices are set by creators and displayed in the currency specified by the creator. Creators are responsible for setting appropriate prices and complying with local tax obligations."
+        ]
+      },
+      {
+        heading: "6. Intellectual Property & Content Ownership",
+        paragraphs: [
+          "Creators retain full ownership of their digital products and content uploaded to Fooshop. By listing products on the Platform, creators grant Fooshop a non-exclusive license to display, promote, and distribute the products as necessary to operate the marketplace.",
+          "Fooshop's brand, logo, AI-generated storefront designs, and Platform code are the intellectual property of Fooshop and may not be used without permission."
+        ]
+      },
+      {
+        heading: "7. Prohibited Content",
+        paragraphs: [
+          "The following content is prohibited on Fooshop: content that infringes on copyrights, trademarks, or other intellectual property rights; illegal content or content promoting illegal activities; malware, viruses, or harmful code; content that is defamatory, harassing, or discriminatory; adult or sexually explicit content unless properly labeled; misleading or fraudulent product listings."
+        ]
+      },
+      {
+        heading: "8. Limitation of Liability",
+        paragraphs: [
+          "Fooshop provides the Platform \"as is\" without warranties of any kind, express or implied. We do not guarantee uninterrupted service, error-free operation, or that the Platform will meet your specific requirements.",
+          "To the maximum extent permitted by law, Fooshop shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the Platform.",
+          "Our total liability for any claim arising from your use of the Platform shall not exceed the amount of commissions paid by you to Fooshop in the 12 months preceding the claim."
+        ]
+      },
+      {
+        heading: "9. Termination",
+        paragraphs: [
+          "Either party may terminate the relationship at any time. Creators may close their account and remove their products. Fooshop may suspend or terminate accounts that violate these terms.",
+          "Upon termination, any pending payments will be processed according to normal schedules. Creators remain responsible for any obligations incurred before termination."
+        ]
+      },
+      {
+        heading: "10. Governing Law",
+        paragraphs: [
+          "These terms are governed by and construed in accordance with the laws of Italy. Any disputes shall be resolved in the courts of Rome, Italy."
+        ]
+      },
+      {
+        heading: "11. Changes to Terms",
+        paragraphs: [
+          "We may modify these Terms of Service at any time. We will notify users of significant changes via email or Platform notification. Your continued use after changes take effect constitutes acceptance of the new terms."
+        ]
+      },
+      {
+        heading: "12. Contact",
+        paragraphs: [
+          "For questions about these Terms of Service, please contact us at legal@fooshop.ai."
+        ]
+      }
+    ]
+  },
+  it: {
+    title: "Termini di Servizio",
+    lastUpdated: "14 marzo 2026",
+    sections: [
+      {
+        heading: "1. Accettazione dei Termini",
+        paragraphs: [
+          "Accedendo o utilizzando Fooshop (\"la Piattaforma\"), gestita da Fooshop (\"noi\", \"nostro\"), accetti di essere vincolato dai presenti Termini di Servizio. Se non accetti questi termini, ti preghiamo di non utilizzare la Piattaforma.",
+          "Ci riserviamo il diritto di aggiornare questi termini in qualsiasi momento. L'uso continuato della Piattaforma dopo le modifiche costituisce accettazione dei termini rivisti."
+        ]
+      },
+      {
+        heading: "2. Descrizione della Piattaforma",
+        paragraphs: [
+          "Fooshop è un marketplace basato su intelligenza artificiale per prodotti digitali. I creator possono vendere beni digitali inclusi ebook, template, corsi, preset, prompt e altri asset digitali. La Piattaforma fornisce vetrine generate dall'IA, elaborazione dei pagamenti e servizi di scoperta prodotti."
+        ]
+      },
+      {
+        heading: "3. Account Creator e Obblighi",
+        paragraphs: [
+          "Per vendere su Fooshop, devi creare un account creator e collegare un account Stripe per l'elaborazione dei pagamenti. Devi avere almeno 18 anni ed essere legalmente in grado di stipulare contratti.",
+          "Come creator, sei responsabile di: l'accuratezza delle tue inserzioni prodotto, la qualità e legalità dei tuoi prodotti digitali, il rispetto di tutte le leggi e regolamenti applicabili, e la risposta tempestiva alle richieste degli acquirenti.",
+          "Non devi vendere prodotti che violano diritti di proprietà intellettuale, contengono malware o codice dannoso, o violano le leggi applicabili."
+        ]
+      },
+      {
+        heading: "4. Diritti dell'Acquirente e Prodotti Digitali",
+        paragraphs: [
+          "Quando acquisti un prodotto digitale su Fooshop, ricevi una licenza per utilizzare quel prodotto come descritto nell'inserzione. Salvo diversa indicazione esplicita, si tratta di una licenza personale, non trasferibile e non esclusiva.",
+          "Data la natura dei prodotti digitali, tutte le vendite sono definitive. I rimborsi possono essere emessi a discrezione del creator o di Fooshop in caso di problemi tecnici che impediscono la consegna del prodotto."
+        ]
+      },
+      {
+        heading: "5. Prezzi, Commissioni e Pagamenti",
+        paragraphs: [
+          "Fooshop applica una commissione del 5% su ogni vendita. Non ci sono costi di abbonamento, costi di inserzione o altri costi nascosti. I creator ricevono il 95% dell'importo di ogni vendita.",
+          "I pagamenti sono elaborati tramite Stripe Connect. I creator vengono pagati direttamente sul loro account Stripe collegato. Fooshop non detiene o gestisce i fondi dei creator oltre l'importo della commissione.",
+          "Tutti i prezzi sono stabiliti dai creator e visualizzati nella valuta specificata dal creator. I creator sono responsabili di impostare prezzi appropriati e di rispettare gli obblighi fiscali locali."
+        ]
+      },
+      {
+        heading: "6. Proprietà Intellettuale e Titolarità dei Contenuti",
+        paragraphs: [
+          "I creator mantengono la piena proprietà dei loro prodotti digitali e dei contenuti caricati su Fooshop. Pubblicando prodotti sulla Piattaforma, i creator concedono a Fooshop una licenza non esclusiva per visualizzare, promuovere e distribuire i prodotti come necessario per il funzionamento del marketplace.",
+          "Il marchio, il logo, i design delle vetrine generati dall'IA e il codice della Piattaforma sono proprietà intellettuale di Fooshop e non possono essere utilizzati senza autorizzazione."
+        ]
+      },
+      {
+        heading: "7. Contenuti Proibiti",
+        paragraphs: [
+          "I seguenti contenuti sono proibiti su Fooshop: contenuti che violano copyright, marchi o altri diritti di proprietà intellettuale; contenuti illegali o che promuovono attività illegali; malware, virus o codice dannoso; contenuti diffamatori, molesti o discriminatori; contenuti per adulti o sessualmente espliciti se non adeguatamente etichettati; inserzioni di prodotti fuorvianti o fraudolente."
+        ]
+      },
+      {
+        heading: "8. Limitazione di Responsabilità",
+        paragraphs: [
+          "Fooshop fornisce la Piattaforma \"così com'è\" senza garanzie di alcun tipo, esplicite o implicite. Non garantiamo un servizio ininterrotto, un funzionamento privo di errori o che la Piattaforma soddisfi le tue esigenze specifiche.",
+          "Nella misura massima consentita dalla legge, Fooshop non sarà responsabile per danni indiretti, incidentali, speciali, consequenziali o punitivi derivanti dall'uso della Piattaforma.",
+          "La nostra responsabilità totale per qualsiasi reclamo derivante dall'uso della Piattaforma non supererà l'importo delle commissioni da te pagate a Fooshop nei 12 mesi precedenti il reclamo."
+        ]
+      },
+      {
+        heading: "9. Risoluzione",
+        paragraphs: [
+          "Ciascuna parte può risolvere il rapporto in qualsiasi momento. I creator possono chiudere il proprio account e rimuovere i propri prodotti. Fooshop può sospendere o chiudere gli account che violano questi termini.",
+          "In caso di risoluzione, eventuali pagamenti in sospeso saranno elaborati secondo le normali tempistiche. I creator restano responsabili per qualsiasi obbligo contratto prima della risoluzione."
+        ]
+      },
+      {
+        heading: "10. Legge Applicabile",
+        paragraphs: [
+          "Questi termini sono regolati e interpretati in conformità alle leggi italiane. Qualsiasi controversia sarà risolta presso i tribunali di Roma, Italia."
+        ]
+      },
+      {
+        heading: "11. Modifiche ai Termini",
+        paragraphs: [
+          "Possiamo modificare questi Termini di Servizio in qualsiasi momento. Notificheremo gli utenti di modifiche significative via email o notifica sulla Piattaforma. L'uso continuato dopo l'entrata in vigore delle modifiche costituisce accettazione dei nuovi termini."
+        ]
+      },
+      {
+        heading: "12. Contatti",
+        paragraphs: [
+          "Per domande su questi Termini di Servizio, contattaci a legal@fooshop.ai."
+        ]
+      }
+    ]
+  }
+};
+```
+
+- [ ] **Step 2: Add Privacy Policy content (EN + IT) to the same file**
+
+Append `privacyContent` export to `src/lib/legal-content.ts`:
+
+```typescript
+export const privacyContent: BilingualLegalDocument = {
+  en: {
+    title: "Privacy Policy",
+    lastUpdated: "March 14, 2026",
+    sections: [
+      {
+        heading: "1. Introduction",
+        paragraphs: [
+          "This Privacy Policy explains how Fooshop (\"we\", \"us\", \"our\") collects, uses, and protects your personal data when you use our platform at fooshop.ai.",
+          "We are committed to protecting your privacy and handling your data in accordance with the General Data Protection Regulation (GDPR) and applicable data protection laws."
+        ]
+      },
+      {
+        heading: "2. Data We Collect",
+        paragraphs: [
+          "Account data: When you sign in with Google, we receive your name, email address, and profile picture. For creators, we also store your store name, description, and slug.",
+          "Payment data: Payment processing is handled by Stripe. We store Stripe Connect account IDs for creators and Stripe payment intent IDs for orders. We do not store credit card numbers or bank account details.",
+          "Product data: Creators upload product information including titles, descriptions, prices, and digital files. Files are stored on Cloudflare R2.",
+          "Analytics data: We collect page view data including timestamps, page paths, and traffic sources (web, MCP, API). We do not track individual user browsing behavior across sessions."
+        ]
+      },
+      {
+        heading: "3. How We Use Your Data",
+        paragraphs: [
+          "We use your data to: operate and maintain the marketplace, process transactions between creators and buyers, provide creator analytics and sales reports, improve the Platform and develop new features, communicate important updates about the service, and comply with legal obligations."
+        ]
+      },
+      {
+        heading: "4. Data Sharing",
+        paragraphs: [
+          "We share data with the following third-party services: Stripe (payment processing — subject to Stripe's privacy policy), Cloudflare R2 (file storage for digital products), and Google (authentication via OAuth).",
+          "We do not sell your personal data to third parties. We may disclose data when required by law or to protect our legal rights."
+        ]
+      },
+      {
+        heading: "5. Cookies & Tracking",
+        paragraphs: [
+          "Fooshop uses essential cookies for authentication and session management. We do not use third-party advertising cookies or cross-site tracking technologies.",
+          "Our analytics collect aggregated page view data without personally identifiable information."
+        ]
+      },
+      {
+        heading: "6. Data Retention",
+        paragraphs: [
+          "We retain your account data for as long as your account is active. Order and transaction data is retained for 7 years for tax and legal compliance. Analytics data is retained in aggregated form.",
+          "When you delete your account, we remove your personal data within 30 days, except where retention is required by law."
+        ]
+      },
+      {
+        heading: "7. Your Rights (GDPR)",
+        paragraphs: [
+          "Under the GDPR, you have the following rights: the right of access — request a copy of your personal data; the right to rectification — correct inaccurate personal data; the right to erasure — request deletion of your personal data; the right to data portability — receive your data in a machine-readable format; the right to restrict processing — limit how we use your data; the right to object — object to processing based on legitimate interests.",
+          "To exercise any of these rights, contact us at privacy@fooshop.ai. We will respond within 30 days."
+        ]
+      },
+      {
+        heading: "8. International Transfers",
+        paragraphs: [
+          "Your data may be processed in countries outside the European Economic Area (EEA) by our service providers (Stripe, Cloudflare). These transfers are protected by appropriate safeguards including Standard Contractual Clauses."
+        ]
+      },
+      {
+        heading: "9. Data Security",
+        paragraphs: [
+          "We implement appropriate technical and organizational measures to protect your data, including encrypted connections (HTTPS), secure authentication via OAuth, and access controls on our systems.",
+          "While we take reasonable precautions, no method of transmission over the Internet is 100% secure. We cannot guarantee absolute security of your data."
+        ]
+      },
+      {
+        heading: "10. Children's Privacy",
+        paragraphs: [
+          "Fooshop is not intended for children under 16 years of age. We do not knowingly collect personal data from children. If we discover that a child has provided us with personal data, we will delete it promptly."
+        ]
+      },
+      {
+        heading: "11. Changes to This Policy",
+        paragraphs: [
+          "We may update this Privacy Policy from time to time. We will notify you of significant changes via email or Platform notification. The \"Last updated\" date at the top of this policy indicates the most recent revision."
+        ]
+      },
+      {
+        heading: "12. Contact",
+        paragraphs: [
+          "For questions about this Privacy Policy or to exercise your data rights, contact us at privacy@fooshop.ai.",
+          "If you believe your data protection rights have been violated, you have the right to lodge a complaint with the Italian Data Protection Authority (Garante per la protezione dei dati personali)."
+        ]
+      }
+    ]
+  },
+  it: {
+    title: "Informativa sulla Privacy",
+    lastUpdated: "14 marzo 2026",
+    sections: [
+      {
+        heading: "1. Introduzione",
+        paragraphs: [
+          "Questa Informativa sulla Privacy spiega come Fooshop (\"noi\", \"nostro\") raccoglie, utilizza e protegge i tuoi dati personali quando utilizzi la nostra piattaforma su fooshop.ai.",
+          "Ci impegniamo a proteggere la tua privacy e a trattare i tuoi dati in conformità al Regolamento Generale sulla Protezione dei Dati (GDPR) e alle leggi applicabili sulla protezione dei dati."
+        ]
+      },
+      {
+        heading: "2. Dati che Raccogliamo",
+        paragraphs: [
+          "Dati dell'account: Quando accedi con Google, riceviamo il tuo nome, indirizzo email e foto profilo. Per i creator, memorizziamo anche il nome del negozio, la descrizione e lo slug.",
+          "Dati di pagamento: L'elaborazione dei pagamenti è gestita da Stripe. Memorizziamo gli ID degli account Stripe Connect per i creator e gli ID degli intenti di pagamento Stripe per gli ordini. Non memorizziamo numeri di carte di credito o dettagli bancari.",
+          "Dati dei prodotti: I creator caricano informazioni sui prodotti inclusi titoli, descrizioni, prezzi e file digitali. I file sono archiviati su Cloudflare R2.",
+          "Dati analitici: Raccogliamo dati sulle visualizzazioni di pagina inclusi timestamp, percorsi delle pagine e fonti di traffico (web, MCP, API). Non tracciamo il comportamento di navigazione individuale degli utenti tra le sessioni."
+        ]
+      },
+      {
+        heading: "3. Come Utilizziamo i Tuoi Dati",
+        paragraphs: [
+          "Utilizziamo i tuoi dati per: gestire e mantenere il marketplace, elaborare transazioni tra creator e acquirenti, fornire analisi e report di vendita ai creator, migliorare la Piattaforma e sviluppare nuove funzionalità, comunicare aggiornamenti importanti sul servizio e rispettare gli obblighi legali."
+        ]
+      },
+      {
+        heading: "4. Condivisione dei Dati",
+        paragraphs: [
+          "Condividiamo i dati con i seguenti servizi di terze parti: Stripe (elaborazione pagamenti — soggetto all'informativa privacy di Stripe), Cloudflare R2 (archiviazione file per prodotti digitali) e Google (autenticazione tramite OAuth).",
+          "Non vendiamo i tuoi dati personali a terzi. Possiamo divulgare i dati quando richiesto dalla legge o per proteggere i nostri diritti legali."
+        ]
+      },
+      {
+        heading: "5. Cookie e Tracciamento",
+        paragraphs: [
+          "Fooshop utilizza cookie essenziali per l'autenticazione e la gestione delle sessioni. Non utilizziamo cookie pubblicitari di terze parti o tecnologie di tracciamento cross-site.",
+          "Le nostre analisi raccolgono dati aggregati sulle visualizzazioni di pagina senza informazioni personali identificabili."
+        ]
+      },
+      {
+        heading: "6. Conservazione dei Dati",
+        paragraphs: [
+          "Conserviamo i dati del tuo account finché il tuo account è attivo. I dati degli ordini e delle transazioni vengono conservati per 7 anni per conformità fiscale e legale. I dati analitici sono conservati in forma aggregata.",
+          "Quando elimini il tuo account, rimuoviamo i tuoi dati personali entro 30 giorni, salvo dove la conservazione è richiesta dalla legge."
+        ]
+      },
+      {
+        heading: "7. I Tuoi Diritti (GDPR)",
+        paragraphs: [
+          "Ai sensi del GDPR, hai i seguenti diritti: diritto di accesso — richiedere una copia dei tuoi dati personali; diritto di rettifica — correggere dati personali inesatti; diritto alla cancellazione — richiedere l'eliminazione dei tuoi dati personali; diritto alla portabilità dei dati — ricevere i tuoi dati in formato leggibile da macchina; diritto di limitazione del trattamento — limitare l'uso dei tuoi dati; diritto di opposizione — opporti al trattamento basato su interessi legittimi.",
+          "Per esercitare uno qualsiasi di questi diritti, contattaci a privacy@fooshop.ai. Risponderemo entro 30 giorni."
+        ]
+      },
+      {
+        heading: "8. Trasferimenti Internazionali",
+        paragraphs: [
+          "I tuoi dati potrebbero essere elaborati in paesi al di fuori dello Spazio Economico Europeo (SEE) dai nostri fornitori di servizi (Stripe, Cloudflare). Questi trasferimenti sono protetti da garanzie appropriate incluse le Clausole Contrattuali Standard."
+        ]
+      },
+      {
+        heading: "9. Sicurezza dei Dati",
+        paragraphs: [
+          "Implementiamo misure tecniche e organizzative appropriate per proteggere i tuoi dati, incluse connessioni crittografate (HTTPS), autenticazione sicura tramite OAuth e controlli di accesso sui nostri sistemi.",
+          "Sebbene prendiamo precauzioni ragionevoli, nessun metodo di trasmissione su Internet è sicuro al 100%. Non possiamo garantire la sicurezza assoluta dei tuoi dati."
+        ]
+      },
+      {
+        heading: "10. Privacy dei Minori",
+        paragraphs: [
+          "Fooshop non è destinato a minori di 16 anni. Non raccogliamo consapevolmente dati personali di minori. Se scopriamo che un minore ci ha fornito dati personali, li cancelleremo tempestivamente."
+        ]
+      },
+      {
+        heading: "11. Modifiche a Questa Informativa",
+        paragraphs: [
+          "Possiamo aggiornare questa Informativa sulla Privacy di tanto in tanto. Ti notificheremo modifiche significative via email o notifica sulla Piattaforma. La data \"Ultimo aggiornamento\" in cima a questa informativa indica la revisione più recente."
+        ]
+      },
+      {
+        heading: "12. Contatti",
+        paragraphs: [
+          "Per domande su questa Informativa sulla Privacy o per esercitare i tuoi diritti sui dati, contattaci a privacy@fooshop.ai.",
+          "Se ritieni che i tuoi diritti alla protezione dei dati siano stati violati, hai il diritto di presentare un reclamo al Garante per la protezione dei dati personali."
+        ]
+      }
+    ]
+  }
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/legal-content.ts
+git commit -m "feat: add legal content data for ToS and Privacy Policy (EN + IT)"
+```
+
+---
+
+## Task 2: Language Toggle Component
+
+**Files:**
+- Create: `src/components/language-toggle.tsx`
+
+Small client component — pill-style EN/IT toggle.
+
+- [ ] **Step 1: Create `src/components/language-toggle.tsx`**
+
+```tsx
+"use client";
+
+type Language = "en" | "it";
+
+interface LanguageToggleProps {
+  language: Language;
+  onChange: (lang: Language) => void;
+}
+
+export function LanguageToggle({ language, onChange }: LanguageToggleProps) {
+  return (
+    <div className="flex rounded-full border border-border overflow-hidden text-sm">
+      <button
+        onClick={() => onChange("en")}
+        className={`px-3 py-1 font-medium transition-colors ${
+          language === "en"
+            ? "bg-ink text-white"
+            : "bg-surface text-muted hover:text-ink"
+        }`}
+      >
+        EN
+      </button>
+      <button
+        onClick={() => onChange("it")}
+        className={`px-3 py-1 font-medium transition-colors ${
+          language === "it"
+            ? "bg-ink text-white"
+            : "bg-surface text-muted hover:text-ink"
+        }`}
+      >
+        IT
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/language-toggle.tsx
+git commit -m "feat: add language toggle component"
+```
+
+---
+
+## Task 3: Legal Page Layout Component
+
+**Files:**
+- Create: `src/components/legal-page.tsx`
+
+Client component that renders a legal document with the language toggle.
+
+- [ ] **Step 1: Create `src/components/legal-page.tsx`**
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { LanguageToggle } from "@/components/language-toggle";
+import type { BilingualLegalDocument } from "@/lib/legal-content";
+
+interface LegalPageProps {
+  content: BilingualLegalDocument;
+}
+
+export function LegalPage({ content }: LegalPageProps) {
+  const [language, setLanguage] = useState<"en" | "it">("en");
+  const doc = content[language];
+
+  return (
+    <article className="max-w-3xl mx-auto px-4 py-16 animate-fade-up">
+      <div className="flex items-start justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-4xl font-bold font-[family-name:var(--font-display)]">{doc.title}</h1>
+          <p className="mt-2 text-sm text-muted">
+            {language === "en" ? "Last updated" : "Ultimo aggiornamento"}:{" "}
+            {doc.lastUpdated}
+          </p>
+        </div>
+        <LanguageToggle language={language} onChange={setLanguage} />
+      </div>
+
+      {doc.sections.map((section) => (
+        <section key={section.heading} className="mb-8">
+          <h2 className="text-xl font-semibold mb-3">{section.heading}</h2>
+          {section.paragraphs.map((paragraph, i) => (
+            <p key={i} className="mb-3 text-muted leading-relaxed">
+              {paragraph}
+            </p>
+          ))}
+        </section>
+      ))}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/legal-page.tsx
+git commit -m "feat: add legal page layout component with language toggle"
+```
+
+---
+
+## Task 4: Terms of Service Page
+
+**Files:**
+- Create: `src/app/(platform)/legal/terms/page.tsx`
+
+Thin server component wrapper — exports metadata, renders `<LegalPage>`.
+
+- [ ] **Step 1: Create directory and page**
+
+```bash
+mkdir -p src/app/\(platform\)/legal/terms
+```
+
+Create `src/app/(platform)/legal/terms/page.tsx`:
+
+```tsx
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal-page";
+import { termsContent } from "@/lib/legal-content";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Fooshop",
+  description:
+    "Terms of Service for Fooshop, the AI-powered marketplace for digital products.",
+};
+
+export default function TermsPage() {
+  return <LegalPage content={termsContent} />;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/\(platform\)/legal/terms/page.tsx
+git commit -m "feat: add Terms of Service page"
+```
+
+---
+
+## Task 5: Privacy Policy Page
+
+**Files:**
+- Create: `src/app/(platform)/legal/privacy/page.tsx`
+
+Same pattern as terms page.
+
+- [ ] **Step 1: Create directory and page**
+
+```bash
+mkdir -p src/app/\(platform\)/legal/privacy
+```
+
+Create `src/app/(platform)/legal/privacy/page.tsx`:
+
+```tsx
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal-page";
+import { privacyContent } from "@/lib/legal-content";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Fooshop",
+  description:
+    "Privacy Policy for Fooshop. How we collect, use, and protect your data.",
+};
+
+export default function PrivacyPage() {
+  return <LegalPage content={privacyContent} />;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/\(platform\)/legal/privacy/page.tsx
+git commit -m "feat: add Privacy Policy page"
+```
+
+---
+
+## Task 6: Footer Component + Layout Integration
+
+**Files:**
+- Create: `src/components/footer.tsx`
+- Modify: `src/app/(platform)/layout.tsx` (add Footer)
+- Modify: `src/app/(platform)/page.tsx` (remove inline footer, lines 87-90)
+
+- [ ] **Step 1: Create `src/components/footer.tsx`**
+
+```tsx
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border">
+      <div className="max-w-6xl mx-auto px-4 py-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted">
+        <div className="flex items-center gap-6">
+          <Link
+            href="/"
+            className="hover:text-ink transition-colors"
+          >
+            Fooshop
+          </Link>
+          <Link
+            href="/legal/terms"
+            className="hover:text-ink transition-colors"
+          >
+            Terms of Service
+          </Link>
+          <Link
+            href="/legal/privacy"
+            className="hover:text-ink transition-colors"
+          >
+            Privacy Policy
+          </Link>
+        </div>
+        <p>&copy; {new Date().getFullYear()} Fooshop</p>
+      </div>
+    </footer>
+  );
+}
+```
+
+- [ ] **Step 2: Update `src/app/(platform)/layout.tsx` — add Footer**
+
+Change from:
+```tsx
+import { Navbar } from "@/components/navbar";
+
+export default function PlatformLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Navbar />
+      {children}
+    </>
+  );
+}
+```
+
+To:
+```tsx
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+
+export default function PlatformLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Navbar />
+      {children}
+      <Footer />
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Remove inline footer from `src/app/(platform)/page.tsx`**
+
+Remove lines 87-90 (the inline `<footer>` element):
+```tsx
+      {/* Footer */}
+      <footer className="text-center py-8 text-sm text-muted">
+        &copy; 2026 Fooshop
+      </footer>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/footer.tsx src/app/\(platform\)/layout.tsx src/app/\(platform\)/page.tsx
+git commit -m "feat: add shared footer to platform layout, remove homepage inline footer"
+```
+
+---
+
+## Task 7: Store Page Footer Updates
+
+**Files:**
+- Modify: `src/app/[slug]/page.tsx` (line 309-311)
+- Modify: `src/app/[slug]/[productSlug]/page.tsx` (line 137-143)
+
+Add legal links to the existing inline footers on store pages.
+
+- [ ] **Step 1: Update store page footer in `src/app/[slug]/page.tsx`**
+
+Change from (lines 309-311):
+```tsx
+        <footer className="mt-16 text-center text-sm opacity-40">
+          Powered by Fooshop
+        </footer>
+```
+
+To:
+```tsx
+        <footer className="mt-16 text-center text-sm opacity-40">
+          <p>Powered by Fooshop</p>
+          <p className="mt-2">
+            <a href="/legal/terms" className="underline hover:opacity-70">Terms</a>
+            {" · "}
+            <a href="/legal/privacy" className="underline hover:opacity-70">Privacy</a>
+          </p>
+        </footer>
+```
+
+- [ ] **Step 2: Update product page footer in `src/app/[slug]/[productSlug]/page.tsx`**
+
+Change from (lines 137-143):
+```tsx
+        <footer className="mt-16 text-sm opacity-40">
+          Sold by{" "}
+          <a href={`/${slug}`} className="underline">
+            {creator.storeName}
+          </a>{" "}
+          on Fooshop
+        </footer>
+```
+
+To:
+```tsx
+        <footer className="mt-16 text-sm opacity-40">
+          <p>
+            Sold by{" "}
+            <a href={`/${slug}`} className="underline">
+              {creator.storeName}
+            </a>{" "}
+            on Fooshop
+          </p>
+          <p className="mt-2">
+            <a href="/legal/terms" className="underline hover:opacity-70">Terms</a>
+            {" · "}
+            <a href="/legal/privacy" className="underline hover:opacity-70">Privacy</a>
+          </p>
+        </footer>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\[slug\]/page.tsx src/app/\[slug\]/\[productSlug\]/page.tsx
+git commit -m "feat: add legal links to store page footers"
+```
+
+---
+
+## Task 8: Sitemap Update
+
+**Files:**
+- Modify: `src/app/sitemap.ts` (line 22-24)
+
+- [ ] **Step 1: Add legal routes to sitemap**
+
+In `src/app/sitemap.ts`, add entries after the existing static routes (after line 24):
+
+Change from:
+```typescript
+  return [
+    { url: BASE_URL, lastModified: new Date() },
+    { url: `${BASE_URL}/explore`, lastModified: new Date() },
+```
+
+To:
+```typescript
+  return [
+    { url: BASE_URL, lastModified: new Date() },
+    { url: `${BASE_URL}/explore`, lastModified: new Date() },
+    { url: `${BASE_URL}/legal/terms`, lastModified: new Date() },
+    { url: `${BASE_URL}/legal/privacy`, lastModified: new Date() },
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/sitemap.ts
+git commit -m "feat: add legal pages to sitemap"
+```
+
+---
+
+## Task 9: Build Verification
+
+- [ ] **Step 1: Run `pnpm build` and verify it passes**
+
+```bash
+pnpm build
+```
+
+Expected: Build succeeds. Output should include:
+- `├ ƒ /legal/terms`
+- `├ ƒ /legal/privacy`
+
+- [ ] **Step 2: Visual check — run dev server and verify pages load**
+
+```bash
+pnpm dev
+```
+
+Check:
+- `http://localhost:3000/legal/terms` — Terms page loads, EN/IT toggle works
+- `http://localhost:3000/legal/privacy` — Privacy page loads, EN/IT toggle works
+- Footer appears on homepage, explore, dashboard pages
+- Store pages show legal links in their footers
+
+- [ ] **Step 3: If any issues found, fix and commit**

--- a/docs/superpowers/specs/2026-03-14-legal-pages-design.md
+++ b/docs/superpowers/specs/2026-03-14-legal-pages-design.md
@@ -1,0 +1,134 @@
+# Legal Pages: Terms of Service & Privacy Policy
+
+**Issue:** #43 [GEN-018]
+**Date:** 2026-03-14
+**Status:** Approved
+
+## Overview
+
+Create publicly accessible Terms of Service and Privacy Policy pages for Fooshop. Required for Stripe Connect compliance and creator trust. Both pages available in English and Italian with a client-side language toggle.
+
+## Architecture
+
+```
+src/
+  app/(platform)/
+    legal/
+      terms/page.tsx        # Terms of Service (server component, exports metadata)
+      privacy/page.tsx      # Privacy Policy (server component, exports metadata)
+  components/
+    footer.tsx              # Shared footer added to (platform)/layout.tsx
+    legal-page.tsx          # Shared legal page layout (client component)
+    language-toggle.tsx     # EN/IT pill toggle (client component)
+  lib/
+    legal-content.ts        # All legal text as structured objects (EN + IT)
+```
+
+## Content Approach
+
+Legal content stored as structured TypeScript objects in `lib/legal-content.ts`, separate from presentation. Each document has EN and IT variants.
+
+```typescript
+type LegalSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+type LegalDocument = {
+  title: string;
+  lastUpdated: string;
+  sections: LegalSection[];
+};
+
+// Exports: termsContent, privacyContent
+// Shape: { en: LegalDocument, it: LegalDocument }
+```
+
+## Footer Component
+
+**Platform pages** (`(platform)` route group — homepage, explore, dashboard, legal, onboarding):
+- Shared `<Footer />` server component added to `(platform)/layout.tsx` after `{children}`
+- Links: Terms of Service, Privacy Policy, Fooshop home
+- Styling: `border-t border-border`, `py-8`, `text-sm text-muted`, `max-w-6xl mx-auto px-4`
+- Responsive: links stack vertically on mobile, horizontal on desktop
+- No animation
+- Replaces the existing inline footer on the homepage
+
+**Store pages** (`[slug]` and `[slug]/[productSlug]` — outside `(platform)` route group):
+- Update existing inline footers to add legal links (Terms · Privacy) alongside current text
+- Keep existing "Powered by Fooshop" / "Sold by ... on Fooshop" text — just append legal links
+- These pages use creator-themed layouts, so a global footer would conflict with theming
+
+## Language Toggle
+
+- Small pill toggle at top-right of content area: `[EN | IT]`
+- Defaults to English
+- Client-side state only (no URL change, no cookie)
+- Single canonical URL per page for SEO
+- Styled: `bg-surface border border-border rounded-full`, active state `bg-ink text-white`
+
+## Legal Page Layout
+
+- `max-w-3xl mx-auto px-4 py-16` for readable line width
+- Title: `h1` Playfair Display, `text-4xl font-bold`
+- Last updated: `text-muted text-sm` below title
+- Sections: `h2` headings (`text-xl font-semibold mb-3`), paragraphs with `text-muted leading-relaxed`
+- `animate-fade-up` on page load
+
+## Terms of Service Sections
+
+1. Acceptance of Terms
+2. Platform Description (AI-powered digital marketplace)
+3. Creator Accounts & Obligations
+4. Buyer Rights & Digital Products
+5. Pricing, Commissions & Payments (5% platform fee, Stripe Connect)
+6. Intellectual Property & Content Ownership
+7. Prohibited Content
+8. Limitation of Liability
+9. Termination
+10. Governing Law
+11. Changes to Terms
+12. Contact
+
+## Privacy Policy Sections
+
+1. Introduction
+2. Data We Collect (account data, payment via Stripe, analytics)
+3. How We Use Your Data
+4. Data Sharing (Stripe, Cloudflare R2, analytics)
+5. Cookies & Tracking
+6. Data Retention
+7. Your Rights (GDPR: access, rectification, erasure, portability)
+8. International Transfers
+9. Data Security
+10. Children's Privacy
+11. Changes to This Policy
+12. Contact (DPO/contact email)
+
+## Metadata
+
+Each legal page exports Next.js metadata for SEO:
+
+```typescript
+// terms/page.tsx
+export const metadata: Metadata = {
+  title: "Terms of Service | Fooshop",
+  description: "Terms of Service for Fooshop, the AI-powered marketplace for digital products.",
+};
+
+// privacy/page.tsx
+export const metadata: Metadata = {
+  title: "Privacy Policy | Fooshop",
+  description: "Privacy Policy for Fooshop. How we collect, use, and protect your data.",
+};
+```
+
+## Additional Changes
+
+- **Sitemap:** Add `/legal/terms` and `/legal/privacy` to `src/app/sitemap.ts`
+
+## Content Language
+
+Both English and Italian, with client-side toggle defaulting to English. Content is drafted as functional legal text tailored to Fooshop's business model (to be lawyer-reviewed before launch).
+
+**SEO trade-off (intentional):** Single canonical URL means search engines index only the default English content. Italian users searching for "termini di servizio fooshop" won't find the Italian version via search. This is acceptable for launch — if Italian SEO becomes important later, we can switch to URL-based language routing with `hreflang` tags.

--- a/src/app/(platform)/layout.tsx
+++ b/src/app/(platform)/layout.tsx
@@ -1,4 +1,5 @@
 import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
 
 export default function PlatformLayout({
   children,
@@ -9,6 +10,7 @@ export default function PlatformLayout({
     <>
       <Navbar />
       {children}
+      <Footer />
     </>
   );
 }

--- a/src/app/(platform)/legal/privacy/page.tsx
+++ b/src/app/(platform)/legal/privacy/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal-page";
+import { privacyContent } from "@/lib/legal-content";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Fooshop",
+  description:
+    "Privacy Policy for Fooshop. How we collect, use, and protect your data.",
+};
+
+export default function PrivacyPage() {
+  return <LegalPage content={privacyContent} />;
+}

--- a/src/app/(platform)/legal/terms/page.tsx
+++ b/src/app/(platform)/legal/terms/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/legal-page";
+import { termsContent } from "@/lib/legal-content";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Fooshop",
+  description:
+    "Terms of Service for Fooshop, the AI-powered marketplace for digital products.",
+};
+
+export default function TermsPage() {
+  return <LegalPage content={termsContent} />;
+}

--- a/src/app/(platform)/page.tsx
+++ b/src/app/(platform)/page.tsx
@@ -84,10 +84,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="text-center py-8 text-sm text-muted">
-        &copy; 2026 Fooshop
-      </footer>
     </main>
   );
 }

--- a/src/app/[slug]/[productSlug]/page.tsx
+++ b/src/app/[slug]/[productSlug]/page.tsx
@@ -135,11 +135,18 @@ export default async function ProductPage({ params }: Props) {
         </div>
 
         <footer className="mt-16 text-sm opacity-40">
-          Sold by{" "}
-          <a href={`/${slug}`} className="underline">
-            {creator.storeName}
-          </a>{" "}
-          on Fooshop
+          <p>
+            Sold by{" "}
+            <a href={`/${slug}`} className="underline">
+              {creator.storeName}
+            </a>{" "}
+            on Fooshop
+          </p>
+          <p className="mt-2">
+            <a href="/legal/terms" className="underline hover:opacity-70">Terms</a>
+            {" · "}
+            <a href="/legal/privacy" className="underline hover:opacity-70">Privacy</a>
+          </p>
         </footer>
       </main>
     </div>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -307,7 +307,12 @@ export default async function StorePage({ params, searchParams }: Props) {
         )}
 
         <footer className="mt-16 text-center text-sm opacity-40">
-          Powered by Fooshop
+          <p>Powered by Fooshop</p>
+          <p className="mt-2">
+            <a href="/legal/terms" className="underline hover:opacity-70">Terms</a>
+            {" · "}
+            <a href="/legal/privacy" className="underline hover:opacity-70">Privacy</a>
+          </p>
         </footer>
       </main>
     </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,6 +22,8 @@ export default async function sitemap() {
   return [
     { url: BASE_URL, lastModified: new Date() },
     { url: `${BASE_URL}/explore`, lastModified: new Date() },
+    { url: `${BASE_URL}/legal/terms`, lastModified: new Date() },
+    { url: `${BASE_URL}/legal/privacy`, lastModified: new Date() },
     ...allCreators.map((c) => ({
       url: `${BASE_URL}/${c.slug}`,
       lastModified: c.createdAt,

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-border">
+      <div className="max-w-6xl mx-auto px-4 py-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted">
+        <div className="flex items-center gap-6">
+          <Link
+            href="/"
+            className="hover:text-ink transition-colors"
+          >
+            Fooshop
+          </Link>
+          <Link
+            href="/legal/terms"
+            className="hover:text-ink transition-colors"
+          >
+            Terms of Service
+          </Link>
+          <Link
+            href="/legal/privacy"
+            className="hover:text-ink transition-colors"
+          >
+            Privacy Policy
+          </Link>
+        </div>
+        <p>&copy; {new Date().getFullYear()} Fooshop</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/language-toggle.tsx
+++ b/src/components/language-toggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+type Language = "en" | "it";
+
+interface LanguageToggleProps {
+  language: Language;
+  onChange: (lang: Language) => void;
+}
+
+export function LanguageToggle({ language, onChange }: LanguageToggleProps) {
+  return (
+    <div role="group" aria-label="Language" className="flex rounded-full border border-border overflow-hidden text-sm">
+      <button
+        onClick={() => onChange("en")}
+        aria-pressed={language === "en"}
+        className={`px-3 py-1 font-medium transition-colors ${
+          language === "en"
+            ? "bg-ink text-white"
+            : "bg-surface text-muted hover:text-ink"
+        }`}
+      >
+        EN
+      </button>
+      <button
+        onClick={() => onChange("it")}
+        aria-pressed={language === "it"}
+        className={`px-3 py-1 font-medium transition-colors ${
+          language === "it"
+            ? "bg-ink text-white"
+            : "bg-surface text-muted hover:text-ink"
+        }`}
+      >
+        IT
+      </button>
+    </div>
+  );
+}

--- a/src/components/legal-page.tsx
+++ b/src/components/legal-page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { LanguageToggle } from "@/components/language-toggle";
+import type { BilingualLegalDocument } from "@/lib/legal-content";
+
+interface LegalPageProps {
+  content: BilingualLegalDocument;
+}
+
+export function LegalPage({ content }: LegalPageProps) {
+  const [language, setLanguage] = useState<"en" | "it">("en");
+  const doc = content[language];
+
+  return (
+    <article lang={language} className="max-w-3xl mx-auto px-4 py-16 animate-fade-up">
+      <div className="flex items-start justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-4xl font-bold font-[family-name:var(--font-display)]">{doc.title}</h1>
+          <p className="mt-2 text-sm text-muted">
+            {language === "en" ? "Last updated" : "Ultimo aggiornamento"}:{" "}
+            {doc.lastUpdated}
+          </p>
+        </div>
+        <LanguageToggle language={language} onChange={setLanguage} />
+      </div>
+
+      {doc.sections.map((section, index) => (
+        <section key={index} className="mb-8">
+          <h2 className="text-xl font-semibold mb-3">{section.heading}</h2>
+          {section.paragraphs.map((paragraph, i) => (
+            <p key={i} className="mb-3 text-muted leading-relaxed">
+              {paragraph}
+            </p>
+          ))}
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/src/lib/legal-content.ts
+++ b/src/lib/legal-content.ts
@@ -1,0 +1,373 @@
+export type LegalSection = {
+  heading: string;
+  paragraphs: string[];
+};
+
+export type LegalDocument = {
+  title: string;
+  lastUpdated: string;
+  sections: LegalSection[];
+};
+
+export type BilingualLegalDocument = {
+  en: LegalDocument;
+  it: LegalDocument;
+};
+
+export const termsContent: BilingualLegalDocument = {
+  en: {
+    title: "Terms of Service",
+    lastUpdated: "March 14, 2026",
+    sections: [
+      {
+        heading: "1. Acceptance of Terms",
+        paragraphs: [
+          "By accessing or using Fooshop (\"the Platform\"), operated by Fooshop (\"we\", \"us\", \"our\"), you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Platform.",
+          "We reserve the right to update these terms at any time. Continued use of the Platform after changes constitutes acceptance of the revised terms."
+        ]
+      },
+      {
+        heading: "2. Platform Description",
+        paragraphs: [
+          "Fooshop is an AI-powered marketplace for digital products. Creators can sell digital goods including ebooks, templates, courses, presets, prompts, and other digital assets. The Platform provides AI-generated storefronts, payment processing, and product discovery services."
+        ]
+      },
+      {
+        heading: "3. Creator Accounts & Obligations",
+        paragraphs: [
+          "To sell on Fooshop, you must create a creator account and connect a Stripe account for payment processing. You must be at least 18 years old and legally able to enter into contracts.",
+          "As a creator, you are responsible for: the accuracy of your product listings, the quality and legality of your digital products, complying with all applicable laws and regulations, and responding to buyer inquiries in a timely manner.",
+          "You must not sell products that infringe on intellectual property rights, contain malware or harmful code, or violate any applicable laws."
+        ]
+      },
+      {
+        heading: "4. Buyer Rights & Digital Products",
+        paragraphs: [
+          "When you purchase a digital product on Fooshop, you receive a license to use that product as described in the product listing. Unless explicitly stated otherwise, this is a personal, non-transferable, non-exclusive license.",
+          "Due to the nature of digital products, all sales are final. Refunds may be issued at the discretion of the creator or Fooshop in cases of technical issues preventing product delivery."
+        ]
+      },
+      {
+        heading: "5. Pricing, Commissions & Payments",
+        paragraphs: [
+          "Fooshop charges a 5% commission on each sale. There are no subscription fees, listing fees, or other hidden costs. Creators receive 95% of each sale amount.",
+          "Payments are processed through Stripe Connect. Creators are paid directly to their connected Stripe account. Fooshop does not hold or manage creator funds beyond the commission amount.",
+          "All prices are set by creators and displayed in the currency specified by the creator. Creators are responsible for setting appropriate prices and complying with local tax obligations."
+        ]
+      },
+      {
+        heading: "6. Intellectual Property & Content Ownership",
+        paragraphs: [
+          "Creators retain full ownership of their digital products and content uploaded to Fooshop. By listing products on the Platform, creators grant Fooshop a non-exclusive license to display, promote, and distribute the products as necessary to operate the marketplace.",
+          "Fooshop's brand, logo, AI-generated storefront designs, and Platform code are the intellectual property of Fooshop and may not be used without permission."
+        ]
+      },
+      {
+        heading: "7. Prohibited Content",
+        paragraphs: [
+          "The following content is prohibited on Fooshop: content that infringes on copyrights, trademarks, or other intellectual property rights; illegal content or content promoting illegal activities; malware, viruses, or harmful code; content that is defamatory, harassing, or discriminatory; adult or sexually explicit content unless properly labeled; misleading or fraudulent product listings."
+        ]
+      },
+      {
+        heading: "8. Limitation of Liability",
+        paragraphs: [
+          "Fooshop provides the Platform \"as is\" without warranties of any kind, express or implied. We do not guarantee uninterrupted service, error-free operation, or that the Platform will meet your specific requirements.",
+          "To the maximum extent permitted by law, Fooshop shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the Platform.",
+          "Our total liability for any claim arising from your use of the Platform shall not exceed the amount of commissions paid by you to Fooshop in the 12 months preceding the claim."
+        ]
+      },
+      {
+        heading: "9. Termination",
+        paragraphs: [
+          "Either party may terminate the relationship at any time. Creators may close their account and remove their products. Fooshop may suspend or terminate accounts that violate these terms.",
+          "Upon termination, any pending payments will be processed according to normal schedules. Creators remain responsible for any obligations incurred before termination."
+        ]
+      },
+      {
+        heading: "10. Governing Law",
+        paragraphs: [
+          "These terms are governed by and construed in accordance with the laws of Italy. Any disputes shall be resolved in the courts of Rome, Italy."
+        ]
+      },
+      {
+        heading: "11. Changes to Terms",
+        paragraphs: [
+          "We may modify these Terms of Service at any time. We will notify users of significant changes via email or Platform notification. Your continued use after changes take effect constitutes acceptance of the new terms."
+        ]
+      },
+      {
+        heading: "12. Contact",
+        paragraphs: [
+          "For questions about these Terms of Service, please contact us at legal@fooshop.ai."
+        ]
+      }
+    ]
+  },
+  it: {
+    title: "Termini di Servizio",
+    lastUpdated: "14 marzo 2026",
+    sections: [
+      {
+        heading: "1. Accettazione dei Termini",
+        paragraphs: [
+          "Accedendo o utilizzando Fooshop (\"la Piattaforma\"), gestita da Fooshop (\"noi\", \"nostro\"), accetti di essere vincolato dai presenti Termini di Servizio. Se non accetti questi termini, ti preghiamo di non utilizzare la Piattaforma.",
+          "Ci riserviamo il diritto di aggiornare questi termini in qualsiasi momento. L'uso continuato della Piattaforma dopo le modifiche costituisce accettazione dei termini rivisti."
+        ]
+      },
+      {
+        heading: "2. Descrizione della Piattaforma",
+        paragraphs: [
+          "Fooshop è un marketplace basato su intelligenza artificiale per prodotti digitali. I creator possono vendere beni digitali inclusi ebook, template, corsi, preset, prompt e altri asset digitali. La Piattaforma fornisce vetrine generate dall'IA, elaborazione dei pagamenti e servizi di scoperta prodotti."
+        ]
+      },
+      {
+        heading: "3. Account Creator e Obblighi",
+        paragraphs: [
+          "Per vendere su Fooshop, devi creare un account creator e collegare un account Stripe per l'elaborazione dei pagamenti. Devi avere almeno 18 anni ed essere legalmente in grado di stipulare contratti.",
+          "Come creator, sei responsabile di: l'accuratezza delle tue inserzioni prodotto, la qualità e legalità dei tuoi prodotti digitali, il rispetto di tutte le leggi e regolamenti applicabili, e la risposta tempestiva alle richieste degli acquirenti.",
+          "Non devi vendere prodotti che violano diritti di proprietà intellettuale, contengono malware o codice dannoso, o violano le leggi applicabili."
+        ]
+      },
+      {
+        heading: "4. Diritti dell'Acquirente e Prodotti Digitali",
+        paragraphs: [
+          "Quando acquisti un prodotto digitale su Fooshop, ricevi una licenza per utilizzare quel prodotto come descritto nell'inserzione. Salvo diversa indicazione esplicita, si tratta di una licenza personale, non trasferibile e non esclusiva.",
+          "Data la natura dei prodotti digitali, tutte le vendite sono definitive. I rimborsi possono essere emessi a discrezione del creator o di Fooshop in caso di problemi tecnici che impediscono la consegna del prodotto."
+        ]
+      },
+      {
+        heading: "5. Prezzi, Commissioni e Pagamenti",
+        paragraphs: [
+          "Fooshop applica una commissione del 5% su ogni vendita. Non ci sono costi di abbonamento, costi di inserzione o altri costi nascosti. I creator ricevono il 95% dell'importo di ogni vendita.",
+          "I pagamenti sono elaborati tramite Stripe Connect. I creator vengono pagati direttamente sul loro account Stripe collegato. Fooshop non detiene o gestisce i fondi dei creator oltre l'importo della commissione.",
+          "Tutti i prezzi sono stabiliti dai creator e visualizzati nella valuta specificata dal creator. I creator sono responsabili di impostare prezzi appropriati e di rispettare gli obblighi fiscali locali."
+        ]
+      },
+      {
+        heading: "6. Proprietà Intellettuale e Titolarità dei Contenuti",
+        paragraphs: [
+          "I creator mantengono la piena proprietà dei loro prodotti digitali e dei contenuti caricati su Fooshop. Pubblicando prodotti sulla Piattaforma, i creator concedono a Fooshop una licenza non esclusiva per visualizzare, promuovere e distribuire i prodotti come necessario per il funzionamento del marketplace.",
+          "Il marchio, il logo, i design delle vetrine generati dall'IA e il codice della Piattaforma sono proprietà intellettuale di Fooshop e non possono essere utilizzati senza autorizzazione."
+        ]
+      },
+      {
+        heading: "7. Contenuti Proibiti",
+        paragraphs: [
+          "I seguenti contenuti sono proibiti su Fooshop: contenuti che violano copyright, marchi o altri diritti di proprietà intellettuale; contenuti illegali o che promuovono attività illegali; malware, virus o codice dannoso; contenuti diffamatori, molesti o discriminatori; contenuti per adulti o sessualmente espliciti se non adeguatamente etichettati; inserzioni di prodotti fuorvianti o fraudolente."
+        ]
+      },
+      {
+        heading: "8. Limitazione di Responsabilità",
+        paragraphs: [
+          "Fooshop fornisce la Piattaforma \"così com'è\" senza garanzie di alcun tipo, esplicite o implicite. Non garantiamo un servizio ininterrotto, un funzionamento privo di errori o che la Piattaforma soddisfi le tue esigenze specifiche.",
+          "Nella misura massima consentita dalla legge, Fooshop non sarà responsabile per danni indiretti, incidentali, speciali, consequenziali o punitivi derivanti dall'uso della Piattaforma.",
+          "La nostra responsabilità totale per qualsiasi reclamo derivante dall'uso della Piattaforma non supererà l'importo delle commissioni da te pagate a Fooshop nei 12 mesi precedenti il reclamo."
+        ]
+      },
+      {
+        heading: "9. Risoluzione",
+        paragraphs: [
+          "Ciascuna parte può risolvere il rapporto in qualsiasi momento. I creator possono chiudere il proprio account e rimuovere i propri prodotti. Fooshop può sospendere o chiudere gli account che violano questi termini.",
+          "In caso di risoluzione, eventuali pagamenti in sospeso saranno elaborati secondo le normali tempistiche. I creator restano responsabili per qualsiasi obbligo contratto prima della risoluzione."
+        ]
+      },
+      {
+        heading: "10. Legge Applicabile",
+        paragraphs: [
+          "Questi termini sono regolati e interpretati in conformità alle leggi italiane. Qualsiasi controversia sarà risolta presso i tribunali di Roma, Italia."
+        ]
+      },
+      {
+        heading: "11. Modifiche ai Termini",
+        paragraphs: [
+          "Possiamo modificare questi Termini di Servizio in qualsiasi momento. Notificheremo gli utenti di modifiche significative via email o notifica sulla Piattaforma. L'uso continuato dopo l'entrata in vigore delle modifiche costituisce accettazione dei nuovi termini."
+        ]
+      },
+      {
+        heading: "12. Contatti",
+        paragraphs: [
+          "Per domande su questi Termini di Servizio, contattaci a legal@fooshop.ai."
+        ]
+      }
+    ]
+  }
+};
+
+export const privacyContent: BilingualLegalDocument = {
+  en: {
+    title: "Privacy Policy",
+    lastUpdated: "March 14, 2026",
+    sections: [
+      {
+        heading: "1. Introduction",
+        paragraphs: [
+          "This Privacy Policy explains how Fooshop (\"we\", \"us\", \"our\") collects, uses, and protects your personal data when you use our platform at fooshop.ai.",
+          "We are committed to protecting your privacy and handling your data in accordance with the General Data Protection Regulation (GDPR) and applicable data protection laws."
+        ]
+      },
+      {
+        heading: "2. Data We Collect",
+        paragraphs: [
+          "Account data: When you sign in with Google, we receive your name, email address, and profile picture. For creators, we also store your store name, description, and slug.",
+          "Payment data: Payment processing is handled by Stripe. We store Stripe Connect account IDs for creators and Stripe payment intent IDs for orders. We do not store credit card numbers or bank account details.",
+          "Product data: Creators upload product information including titles, descriptions, prices, and digital files. Files are stored on Cloudflare R2.",
+          "Analytics data: We collect page view data including timestamps, page paths, and traffic sources (web, MCP, API). We do not track individual user browsing behavior across sessions."
+        ]
+      },
+      {
+        heading: "3. How We Use Your Data",
+        paragraphs: [
+          "We use your data to: operate and maintain the marketplace, process transactions between creators and buyers, provide creator analytics and sales reports, improve the Platform and develop new features, communicate important updates about the service, and comply with legal obligations."
+        ]
+      },
+      {
+        heading: "4. Data Sharing",
+        paragraphs: [
+          "We share data with the following third-party services: Stripe (payment processing — subject to Stripe's privacy policy), Cloudflare R2 (file storage for digital products), and Google (authentication via OAuth).",
+          "We do not sell your personal data to third parties. We may disclose data when required by law or to protect our legal rights."
+        ]
+      },
+      {
+        heading: "5. Cookies & Tracking",
+        paragraphs: [
+          "Fooshop uses essential cookies for authentication and session management. We do not use third-party advertising cookies or cross-site tracking technologies.",
+          "Our analytics collect aggregated page view data without personally identifiable information."
+        ]
+      },
+      {
+        heading: "6. Data Retention",
+        paragraphs: [
+          "We retain your account data for as long as your account is active. Order and transaction data is retained for 7 years for tax and legal compliance. Analytics data is retained in aggregated form.",
+          "When you delete your account, we remove your personal data within 30 days, except where retention is required by law."
+        ]
+      },
+      {
+        heading: "7. Your Rights (GDPR)",
+        paragraphs: [
+          "Under the GDPR, you have the following rights: the right of access — request a copy of your personal data; the right to rectification — correct inaccurate personal data; the right to erasure — request deletion of your personal data; the right to data portability — receive your data in a machine-readable format; the right to restrict processing — limit how we use your data; the right to object — object to processing based on legitimate interests.",
+          "To exercise any of these rights, contact us at privacy@fooshop.ai. We will respond within 30 days."
+        ]
+      },
+      {
+        heading: "8. International Transfers",
+        paragraphs: [
+          "Your data may be processed in countries outside the European Economic Area (EEA) by our service providers (Stripe, Cloudflare). These transfers are protected by appropriate safeguards including Standard Contractual Clauses."
+        ]
+      },
+      {
+        heading: "9. Data Security",
+        paragraphs: [
+          "We implement appropriate technical and organizational measures to protect your data, including encrypted connections (HTTPS), secure authentication via OAuth, and access controls on our systems.",
+          "While we take reasonable precautions, no method of transmission over the Internet is 100% secure. We cannot guarantee absolute security of your data."
+        ]
+      },
+      {
+        heading: "10. Children's Privacy",
+        paragraphs: [
+          "Fooshop is not intended for children under 16 years of age. We do not knowingly collect personal data from children. If we discover that a child has provided us with personal data, we will delete it promptly."
+        ]
+      },
+      {
+        heading: "11. Changes to This Policy",
+        paragraphs: [
+          "We may update this Privacy Policy from time to time. We will notify you of significant changes via email or Platform notification. The \"Last updated\" date at the top of this policy indicates the most recent revision."
+        ]
+      },
+      {
+        heading: "12. Contact",
+        paragraphs: [
+          "For questions about this Privacy Policy or to exercise your data rights, contact us at privacy@fooshop.ai.",
+          "If you believe your data protection rights have been violated, you have the right to lodge a complaint with the Italian Data Protection Authority (Garante per la protezione dei dati personali)."
+        ]
+      }
+    ]
+  },
+  it: {
+    title: "Informativa sulla Privacy",
+    lastUpdated: "14 marzo 2026",
+    sections: [
+      {
+        heading: "1. Introduzione",
+        paragraphs: [
+          "Questa Informativa sulla Privacy spiega come Fooshop (\"noi\", \"nostro\") raccoglie, utilizza e protegge i tuoi dati personali quando utilizzi la nostra piattaforma su fooshop.ai.",
+          "Ci impegniamo a proteggere la tua privacy e a trattare i tuoi dati in conformità al Regolamento Generale sulla Protezione dei Dati (GDPR) e alle leggi applicabili sulla protezione dei dati."
+        ]
+      },
+      {
+        heading: "2. Dati che Raccogliamo",
+        paragraphs: [
+          "Dati dell'account: Quando accedi con Google, riceviamo il tuo nome, indirizzo email e foto profilo. Per i creator, memorizziamo anche il nome del negozio, la descrizione e lo slug.",
+          "Dati di pagamento: L'elaborazione dei pagamenti è gestita da Stripe. Memorizziamo gli ID degli account Stripe Connect per i creator e gli ID degli intenti di pagamento Stripe per gli ordini. Non memorizziamo numeri di carte di credito o dettagli bancari.",
+          "Dati dei prodotti: I creator caricano informazioni sui prodotti inclusi titoli, descrizioni, prezzi e file digitali. I file sono archiviati su Cloudflare R2.",
+          "Dati analitici: Raccogliamo dati sulle visualizzazioni di pagina inclusi timestamp, percorsi delle pagine e fonti di traffico (web, MCP, API). Non tracciamo il comportamento di navigazione individuale degli utenti tra le sessioni."
+        ]
+      },
+      {
+        heading: "3. Come Utilizziamo i Tuoi Dati",
+        paragraphs: [
+          "Utilizziamo i tuoi dati per: gestire e mantenere il marketplace, elaborare transazioni tra creator e acquirenti, fornire analisi e report di vendita ai creator, migliorare la Piattaforma e sviluppare nuove funzionalità, comunicare aggiornamenti importanti sul servizio e rispettare gli obblighi legali."
+        ]
+      },
+      {
+        heading: "4. Condivisione dei Dati",
+        paragraphs: [
+          "Condividiamo i dati con i seguenti servizi di terze parti: Stripe (elaborazione pagamenti — soggetto all'informativa privacy di Stripe), Cloudflare R2 (archiviazione file per prodotti digitali) e Google (autenticazione tramite OAuth).",
+          "Non vendiamo i tuoi dati personali a terzi. Possiamo divulgare i dati quando richiesto dalla legge o per proteggere i nostri diritti legali."
+        ]
+      },
+      {
+        heading: "5. Cookie e Tracciamento",
+        paragraphs: [
+          "Fooshop utilizza cookie essenziali per l'autenticazione e la gestione delle sessioni. Non utilizziamo cookie pubblicitari di terze parti o tecnologie di tracciamento cross-site.",
+          "Le nostre analisi raccolgono dati aggregati sulle visualizzazioni di pagina senza informazioni personali identificabili."
+        ]
+      },
+      {
+        heading: "6. Conservazione dei Dati",
+        paragraphs: [
+          "Conserviamo i dati del tuo account finché il tuo account è attivo. I dati degli ordini e delle transazioni vengono conservati per 7 anni per conformità fiscale e legale. I dati analitici sono conservati in forma aggregata.",
+          "Quando elimini il tuo account, rimuoviamo i tuoi dati personali entro 30 giorni, salvo dove la conservazione è richiesta dalla legge."
+        ]
+      },
+      {
+        heading: "7. I Tuoi Diritti (GDPR)",
+        paragraphs: [
+          "Ai sensi del GDPR, hai i seguenti diritti: diritto di accesso — richiedere una copia dei tuoi dati personali; diritto di rettifica — correggere dati personali inesatti; diritto alla cancellazione — richiedere l'eliminazione dei tuoi dati personali; diritto alla portabilità dei dati — ricevere i tuoi dati in formato leggibile da macchina; diritto di limitazione del trattamento — limitare l'uso dei tuoi dati; diritto di opposizione — opporti al trattamento basato su interessi legittimi.",
+          "Per esercitare uno qualsiasi di questi diritti, contattaci a privacy@fooshop.ai. Risponderemo entro 30 giorni."
+        ]
+      },
+      {
+        heading: "8. Trasferimenti Internazionali",
+        paragraphs: [
+          "I tuoi dati potrebbero essere elaborati in paesi al di fuori dello Spazio Economico Europeo (SEE) dai nostri fornitori di servizi (Stripe, Cloudflare). Questi trasferimenti sono protetti da garanzie appropriate incluse le Clausole Contrattuali Standard."
+        ]
+      },
+      {
+        heading: "9. Sicurezza dei Dati",
+        paragraphs: [
+          "Implementiamo misure tecniche e organizzative appropriate per proteggere i tuoi dati, incluse connessioni crittografate (HTTPS), autenticazione sicura tramite OAuth e controlli di accesso sui nostri sistemi.",
+          "Sebbene prendiamo precauzioni ragionevoli, nessun metodo di trasmissione su Internet è sicuro al 100%. Non possiamo garantire la sicurezza assoluta dei tuoi dati."
+        ]
+      },
+      {
+        heading: "10. Privacy dei Minori",
+        paragraphs: [
+          "Fooshop non è destinato a minori di 16 anni. Non raccogliamo consapevolmente dati personali di minori. Se scopriamo che un minore ci ha fornito dati personali, li cancelleremo tempestivamente."
+        ]
+      },
+      {
+        heading: "11. Modifiche a Questa Informativa",
+        paragraphs: [
+          "Possiamo aggiornare questa Informativa sulla Privacy di tanto in tanto. Ti notificheremo modifiche significative via email o notifica sulla Piattaforma. La data \"Ultimo aggiornamento\" in cima a questa informativa indica la revisione più recente."
+        ]
+      },
+      {
+        heading: "12. Contatti",
+        paragraphs: [
+          "Per domande su questa Informativa sulla Privacy o per esercitare i tuoi diritti sui dati, contattaci a privacy@fooshop.ai.",
+          "Se ritieni che i tuoi diritti alla protezione dei dati siano stati violati, hai il diritto di presentare un reclamo al Garante per la protezione dei dati personali."
+        ]
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Closes #43

## Summary
- Created `/legal/terms` and `/legal/privacy` pages with EN/IT language toggle
- Added shared `<Footer />` component to all platform pages with legal links
- Updated store page footers (`[slug]`, `[slug]/[productSlug]`) with Terms/Privacy links
- Added legal pages to sitemap
- Accessibility: `aria-pressed` on toggle, `lang` attribute on content

## Test plan
- [ ] Verify `/legal/terms` loads correctly with all 12 sections
- [ ] Verify `/legal/privacy` loads correctly with all 12 sections
- [ ] Verify EN/IT toggle switches content on both pages
- [ ] Verify footer appears on homepage, explore, dashboard, legal pages
- [ ] Verify store pages show Terms/Privacy links in footer
- [ ] Verify sitemap includes legal page URLs