### PR TITLE
[Issue #44] Gestione refund nel webhook Stripe

### DIFF
--- a/docs/superpowers/plans/2026-03-14-stripe-refund-webhook.md
+++ b/docs/superpowers/plans/2026-03-14-stripe-refund-webhook.md
@@ -1,0 +1,100 @@
+# Stripe Refund Webhook Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Handle `charge.refunded` Stripe webhook events to mark orders as "refunded" and revoke download access.
+
+**Architecture:** Add a new event case to the existing webhook handler at `src/app/api/stripe/webhook/route.ts`. Uses a DB transaction to atomically update order status and expire download tokens.
+
+**Tech Stack:** Next.js API route, Drizzle ORM, Stripe SDK, PostgreSQL
+
+**Spec:** `docs/superpowers/specs/2026-03-14-stripe-refund-webhook-design.md`
+
+---
+
+## Chunk 1: Implementation
+
+### Task 1: Add `charge.refunded` handler to webhook
+
+**Files:**
+- Modify: `src/app/api/stripe/webhook/route.ts:146` (before the final `return`)
+
+**Context:** The existing webhook handler is at `src/app/api/stripe/webhook/route.ts`. It handles `checkout.session.completed` (lines 23-145) then returns `{ received: true }` on line 148. The new `charge.refunded` case goes between line 146 and the final return.
+
+**Imports needed:** None — the existing `eq` import is sufficient.
+
+- [ ] **Step 1: Add `charge.refunded` event handler**
+
+Insert the following block after line 146 (after the closing `}` of the `checkout.session.completed` block) and before the final `return NextResponse.json({ received: true })`:
+
+```typescript
+  if (event.type === "charge.refunded") {
+    const charge = event.data.object;
+
+    // Extract payment_intent ID (can be string, expanded object, or null)
+    const paymentIntentId =
+      typeof charge.payment_intent === "string"
+        ? charge.payment_intent
+        : charge.payment_intent?.id;
+
+    if (!paymentIntentId) {
+      console.warn("Webhook: charge.refunded missing payment_intent", { chargeId: charge.id });
+      return NextResponse.json({ received: true });
+    }
+
+    // Look up order by payment intent
+    const order = await db
+      .select({ id: orders.id, status: orders.status })
+      .from(orders)
+      .where(eq(orders.stripePaymentIntentId, paymentIntentId))
+      .then((rows) => rows[0]);
+
+    if (!order) {
+      console.warn("Webhook: charge.refunded order not found", { paymentIntentId });
+      return NextResponse.json({ received: true });
+    }
+
+    // Idempotency: skip if already refunded
+    if (order.status === "refunded") {
+      return NextResponse.json({ received: true });
+    }
+
+    try {
+      await db.transaction(async (tx) => {
+        // Update order status to refunded
+        await tx
+          .update(orders)
+          .set({ status: "refunded" })
+          .where(eq(orders.id, order.id));
+
+        // Expire all download tokens for this order
+        await tx
+          .update(downloadTokens)
+          .set({ expiresAt: new Date() })
+          .where(eq(downloadTokens.orderId, order.id));
+      });
+    } catch (error) {
+      console.error("Webhook: failed to process charge.refunded", {
+        chargeId: charge.id,
+        orderId: order.id,
+        error,
+      });
+      return NextResponse.json({ error: "Processing failed" }, { status: 500 });
+    }
+  }
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `pnpm build`
+Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/stripe/webhook/route.ts
+git commit -m "feat: handle charge.refunded webhook event (#44)
+
+Update order status to 'refunded' and expire download tokens
+when Stripe fires a charge.refunded event."
+```

--- a/docs/superpowers/specs/2026-03-14-stripe-refund-webhook-design.md
+++ b/docs/superpowers/specs/2026-03-14-stripe-refund-webhook-design.md
@@ -1,0 +1,79 @@
+# [GEN-019] Stripe Refund Webhook Design
+
+**Issue:** #44
+**Date:** 2026-03-14
+**Status:** Approved
+
+## Problem
+
+When a refund occurs on Stripe, Fooshop's order stays "completed" and download tokens remain active — data becomes inconsistent, and buyers retain access to files they were refunded for.
+
+## Solution
+
+Handle `charge.refunded` in the existing Stripe webhook. Update order status to "refunded" and expire associated download tokens.
+
+## Design
+
+### Event: `charge.refunded`
+
+Added as a new case in `src/app/api/stripe/webhook/route.ts`, following the existing `checkout.session.completed` pattern.
+
+**Flow:**
+
+1. Extract `payment_intent` from charge object (handle string, expanded object, or null)
+   - `typeof charge.payment_intent === 'string' ? charge.payment_intent : charge.payment_intent?.id`
+   - If null → return 200 (not a PaymentIntent-based charge)
+2. Look up order by `stripePaymentIntentId`
+3. Guard: if order not found or already "refunded" → return 200 (idempotent no-op)
+4. DB transaction:
+   - Update order status to `"refunded"`
+   - Set `expiresAt = now()` on all download tokens for that order
+5. Return 200
+
+**Business decision:** Any `charge.refunded` event (partial or full) marks the order as fully refunded and revokes download access. This is intentional for launch — partial refund differentiation can be added later if needed.
+
+### Idempotency
+
+- If order already has status `"refunded"`, skip silently (return 200)
+- Stripe retries on 5xx, so DB errors naturally get retried
+
+### Token Invalidation Strategy
+
+Set `expiresAt = new Date()` rather than deleting the token row. This:
+- Works with the existing download route (`expiresAt > now` check → returns 410)
+- Preserves audit trail
+- Requires no schema changes
+
+### Error Handling
+
+| Scenario | Response | Reason |
+|----------|----------|--------|
+| Order not found | 200 + log warning | Don't retry for missing data |
+| Already refunded | 200 | Idempotent |
+| DB error | 500 | Stripe will retry |
+
+### Files Changed
+
+- `src/app/api/stripe/webhook/route.ts` — add `charge.refunded` case
+
+### Prerequisites
+
+- Add `charge.refunded` to the Stripe webhook endpoint event list in the Stripe Dashboard (or via API)
+
+### Assumptions
+
+- Fooshop uses Stripe Connect destination charges. The `charge.refunded` event fires on the **platform** account for refunds initiated from the platform dashboard. Refunds initiated from a connected account's dashboard may not trigger this event on the platform.
+
+### Known Limitations
+
+- **Partial refunds treated as full:** Any refund revokes access (see business decision above)
+- **Coupon redemption count not decremented:** A refunded order's coupon use still counts toward `maxRedemptions` — could cause a coupon to appear exhausted prematurely
+- **Race condition:** If `charge.refunded` arrives before `checkout.session.completed` (e.g., Stripe Radar), the refund is a no-op and the order is created as "completed". Requires manual reconciliation in this rare edge case.
+- **Download route has no order-status check:** Token expiry is the sole access gate. A defense-in-depth order status check could be added later.
+
+### Out of Scope
+
+- Refund email notification to buyer
+- Coupon redemption count reversal
+- Referral conversion reversal
+- `refundedAt` timestamp on orders table

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -145,5 +145,61 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Partial and full refunds both revoke access (see spec GEN-019)
+  if (event.type === "charge.refunded") {
+    const charge = event.data.object;
+
+    // Extract payment_intent ID (can be string, expanded object, or null)
+    const paymentIntentId =
+      typeof charge.payment_intent === "string"
+        ? charge.payment_intent
+        : charge.payment_intent?.id;
+
+    if (!paymentIntentId) {
+      console.warn("Webhook: charge.refunded missing payment_intent", { chargeId: charge.id });
+      return NextResponse.json({ received: true });
+    }
+
+    // Look up order by payment intent
+    const order = await db
+      .select({ id: orders.id, status: orders.status })
+      .from(orders)
+      .where(eq(orders.stripePaymentIntentId, paymentIntentId))
+      .then((rows) => rows[0]);
+
+    if (!order) {
+      console.warn("Webhook: charge.refunded order not found", { paymentIntentId });
+      return NextResponse.json({ received: true });
+    }
+
+    // Idempotency: skip if already refunded
+    if (order.status === "refunded") {
+      return NextResponse.json({ received: true });
+    }
+
+    try {
+      await db.transaction(async (tx) => {
+        // Update order status to refunded
+        await tx
+          .update(orders)
+          .set({ status: "refunded" })
+          .where(eq(orders.id, order.id));
+
+        // Expire all download tokens for this order
+        await tx
+          .update(downloadTokens)
+          .set({ expiresAt: new Date() })
+          .where(eq(downloadTokens.orderId, order.id));
+      });
+    } catch (error) {
+      console.error("Webhook: failed to process charge.refunded", {
+        chargeId: charge.id,
+        orderId: order.id,
+        error,
+      });
+      return NextResponse.json({ error: "Processing failed" }, { status: 500 });
+    }
+  }
+
   return NextResponse.json({ received: true });
 }


### PR DESCRIPTION
Closes #44

## Summary
- Handle `charge.refunded` Stripe webhook event
- Update order status to "refunded" in a DB transaction
- Expire download tokens by setting `expiresAt = now()` (revokes buyer access)

## Test plan
- [ ] Verify on staging with Stripe CLI: `stripe trigger charge.refunded`
- [ ] Confirm order status updates to "refunded" in DB
- [ ] Confirm download tokens are expired (download returns 410)
- [ ] Verify idempotency: sending same event twice has no side effects
- [ ] Add `charge.refunded` to Stripe webhook endpoint in Dashboard