### PR TITLE
[Issue #45] Override 0% commissione per primi 50 creator

### DIFF
--- a/docs/superpowers/plans/2026-03-15-commission-override.md
+++ b/docs/superpowers/plans/2026-03-15-commission-override.md
@@ -1,0 +1,744 @@
+# Commission Override Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow early-bird creators to have a custom commission rate (e.g. 0%) for a defined period, managed via a Claude Code CLI skill.
+
+**Architecture:** Two nullable columns on `creators` table control override. `calculatePlatformFee()` gains an optional creator parameter. Webhook reads fee from Stripe session instead of recalculating. Dashboard shows a banner when override is active. A `/creators` CLI skill wraps a Node.js admin script for management.
+
+**Tech Stack:** Drizzle ORM (schema + migration), TypeScript, Next.js App Router, Vitest (unit tests), Claude Code skill (SKILL.md)
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/db/schema.ts` | Add two nullable columns to `creators` |
+| Modify | `src/lib/stripe.ts` | Update `calculatePlatformFee` with optional creator param |
+| Modify | `src/app/api/checkout/route.ts` | Pass creator override fields to fee calculation |
+| Modify | `src/app/api/stripe/webhook/route.ts` | Read `application_fee_amount` from Stripe payment intent |
+| Modify | `src/app/(platform)/dashboard/page.tsx` | Add promotion banner |
+| Create | `src/scripts/creators-admin.ts` | CLI admin script for creator management |
+| Create | `src/lib/commission.ts` | Helper to check if override is active (shared by dashboard + fee calc) |
+| Create | `.claude/skills/creators/SKILL.md` | Claude Code skill definition |
+| Create | `src/lib/__tests__/commission.test.ts` | Unit tests for commission logic |
+| Modify | `src/scripts/seed.ts` | Add override fields to one seed creator |
+
+---
+
+## Chunk 1: Core Logic
+
+### Task 1: Schema — Add override columns to creators
+
+**Files:**
+- Modify: `src/db/schema.ts:133-149`
+
+- [ ] **Step 1: Add two nullable columns to creators table**
+
+In `src/db/schema.ts`, add to the `creators` table definition (after `storeTheme` field, before `createdAt`):
+
+```ts
+commissionOverridePercent: integer("commission_override_percent"),
+commissionOverrideExpiresAt: timestamp("commission_override_expires_at", { withTimezone: true }),
+```
+
+- [ ] **Step 2: Generate and push migration**
+
+Run: `pnpm drizzle-kit generate`
+Expected: New migration file created in drizzle output directory.
+
+Run: `pnpm drizzle-kit push`
+Expected: Schema pushed successfully, two new nullable columns on `creators`.
+
+- [ ] **Step 3: Verify with build**
+
+Run: `pnpm build`
+Expected: Build succeeds (nullable columns don't break existing code).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/schema.ts drizzle/
+git commit -m "feat(schema): add commission override columns to creators (#45)"
+```
+
+---
+
+### Task 2: Commission helper — isOverrideActive + fee calculation
+
+**Files:**
+- Create: `src/lib/commission.ts`
+- Create: `src/lib/__tests__/commission.test.ts`
+- Modify: `src/lib/stripe.ts`
+
+- [ ] **Step 1: Create vitest config for unit tests**
+
+Check if a `vitest.config.ts` (not smoke) exists. If not, create `vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});
+```
+
+Add `"test"` script to `package.json`:
+
+```json
+"test": "vitest run",
+```
+
+- [ ] **Step 2: Write failing tests for commission logic**
+
+Create `src/lib/__tests__/commission.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isOverrideActive, getEffectiveCommissionPercent } from "../commission";
+
+describe("isOverrideActive", () => {
+  it("returns false when override percent is null", () => {
+    expect(isOverrideActive(null, null)).toBe(false);
+  });
+
+  it("returns true when override is set with no expiry", () => {
+    expect(isOverrideActive(0, null)).toBe(true);
+  });
+
+  it("returns true when override is set and expiry is in the future", () => {
+    const future = new Date(Date.now() + 86400000);
+    expect(isOverrideActive(0, future)).toBe(true);
+  });
+
+  it("returns false when override is set but expired", () => {
+    const past = new Date(Date.now() - 86400000);
+    expect(isOverrideActive(0, past)).toBe(false);
+  });
+
+  it("returns true for non-zero override percent", () => {
+    expect(isOverrideActive(3, null)).toBe(true);
+  });
+});
+
+describe("getEffectiveCommissionPercent", () => {
+  it("returns default 5 when no creator provided", () => {
+    expect(getEffectiveCommissionPercent()).toBe(5);
+  });
+
+  it("returns default 5 when override is null", () => {
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: null,
+      commissionOverrideExpiresAt: null,
+    })).toBe(5);
+  });
+
+  it("returns 0 when active 0% override", () => {
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 0,
+      commissionOverrideExpiresAt: null,
+    })).toBe(0);
+  });
+
+  it("returns default 5 when override is expired", () => {
+    const past = new Date(Date.now() - 86400000);
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 0,
+      commissionOverrideExpiresAt: past,
+    })).toBe(5);
+  });
+
+  it("returns custom percent when active", () => {
+    const future = new Date(Date.now() + 86400000);
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 2,
+      commissionOverrideExpiresAt: future,
+    })).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm test`
+Expected: FAIL — module `../commission` not found.
+
+- [ ] **Step 4: Implement commission helper**
+
+Create `src/lib/commission.ts`:
+
+```ts
+const DEFAULT_COMMISSION_PERCENT = 5;
+
+export type CommissionOverride = {
+  commissionOverridePercent: number | null;
+  commissionOverrideExpiresAt: Date | null;
+};
+
+export function isOverrideActive(
+  percent: number | null,
+  expiresAt: Date | null
+): boolean {
+  if (percent === null) return false;
+  if (expiresAt === null) return true;
+  return expiresAt > new Date();
+}
+
+export function getEffectiveCommissionPercent(
+  creator?: CommissionOverride
+): number {
+  if (!creator) return DEFAULT_COMMISSION_PERCENT;
+  if (isOverrideActive(creator.commissionOverridePercent, creator.commissionOverrideExpiresAt)) {
+    return creator.commissionOverridePercent!;
+  }
+  return DEFAULT_COMMISSION_PERCENT;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test`
+Expected: All 10 tests PASS.
+
+- [ ] **Step 6: Update calculatePlatformFee to use commission helper**
+
+In `src/lib/stripe.ts`, replace:
+
+```ts
+const PLATFORM_FEE_PERCENT = 5;
+
+export function calculatePlatformFee(amountCents: number): number {
+  return Math.round((amountCents * PLATFORM_FEE_PERCENT) / 100);
+}
+```
+
+With:
+
+```ts
+import { getEffectiveCommissionPercent, type CommissionOverride } from "./commission";
+
+export function calculatePlatformFee(
+  amountCents: number,
+  creator?: CommissionOverride
+): number {
+  const percent = getEffectiveCommissionPercent(creator);
+  return Math.round((amountCents * percent) / 100);
+}
+```
+
+- [ ] **Step 7: Run tests + build to verify nothing breaks**
+
+Run: `pnpm test && pnpm build`
+Expected: Tests pass, build succeeds. Existing callers still work (creator param is optional).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/commission.ts src/lib/__tests__/commission.test.ts src/lib/stripe.ts vitest.config.ts package.json
+git commit -m "feat: add commission override logic with tests (#45)"
+```
+
+---
+
+### Task 3: Update checkout route to pass creator override
+
+**Files:**
+- Modify: `src/app/api/checkout/route.ts:121`
+
+- [ ] **Step 1: Pass creator to calculatePlatformFee**
+
+In `src/app/api/checkout/route.ts`, line 121, change:
+
+```ts
+const platformFee = calculatePlatformFee(finalPriceCents);
+```
+
+To:
+
+```ts
+const platformFee = calculatePlatformFee(finalPriceCents, creator);
+```
+
+The `creator` object is already fetched at line 21-25 and will include the new nullable fields from the schema change.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/checkout/route.ts
+git commit -m "feat(checkout): use commission override in fee calculation (#45)"
+```
+
+---
+
+### Task 4: Update webhook to read fee from Stripe session
+
+**Files:**
+- Modify: `src/app/api/stripe/webhook/route.ts:43-56`
+
+- [ ] **Step 1: Replace recalculated fee with Stripe's actual fee**
+
+In `src/app/api/stripe/webhook/route.ts`, inside the transaction (around line 45-56), the order insert currently has:
+
+```ts
+platformFeeCents: calculatePlatformFee(session.amount_total!),
+```
+
+Replace with reading the actual fee from the Stripe payment intent:
+
+```ts
+// Read the actual application fee from Stripe (authoritative, set at checkout time)
+const paymentIntent = await getStripe().paymentIntents.retrieve(
+  session.payment_intent as string
+);
+const actualPlatformFee = paymentIntent.application_fee_amount ?? 0;
+```
+
+Move this BEFORE the transaction block (after the idempotency check, before `try`). Then update the insert:
+
+```ts
+platformFeeCents: actualPlatformFee,
+```
+
+- [ ] **Step 2: Remove unused calculatePlatformFee import**
+
+In the same file, update the import from:
+
+```ts
+import { getStripe, calculatePlatformFee } from "@/lib/stripe";
+```
+
+To:
+
+```ts
+import { getStripe } from "@/lib/stripe";
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/stripe/webhook/route.ts
+git commit -m "fix(webhook): read platform fee from Stripe payment intent (#45)
+
+Instead of recalculating the fee (which could diverge with time-sensitive
+commission overrides), read the authoritative application_fee_amount
+from the Stripe payment intent."
+```
+
+---
+
+## Chunk 2: Dashboard + CLI
+
+### Task 5: Dashboard promotion banner
+
+**Files:**
+- Modify: `src/app/(platform)/dashboard/page.tsx:45-77`
+
+- [ ] **Step 1: Add import for commission helper**
+
+At the top of `src/app/(platform)/dashboard/page.tsx`, add:
+
+```ts
+import { isOverrideActive } from "@/lib/commission";
+```
+
+- [ ] **Step 2: Compute override status after creator fetch**
+
+After line 24 (`if (!creator) redirect("/onboarding");`), add:
+
+```ts
+const hasActivePromotion = isOverrideActive(
+  creator.commissionOverridePercent,
+  creator.commissionOverrideExpiresAt
+);
+```
+
+- [ ] **Step 3: Add banner JSX between Stripe CTA and quick actions**
+
+After the Stripe CTA block (line 76, closing `</div>` + `})`), add:
+
+```tsx
+{/* Commission override banner */}
+{hasActivePromotion && (
+  <div className="mt-8 bg-green-50 border border-green-200 rounded-xl px-5 py-4 animate-fade-up stagger-4">
+    <p className="text-green-800 font-semibold">
+      {creator.commissionOverridePercent}% commission
+      {creator.commissionOverrideExpiresAt && (
+        <span className="font-normal text-green-700">
+          {" "}— Your early-bird promotion is active until{" "}
+          {new Date(creator.commissionOverrideExpiresAt).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </span>
+      )}
+      {!creator.commissionOverrideExpiresAt && (
+        <span className="font-normal text-green-700">
+          {" "}— Your promotional rate is permanently active
+        </span>
+      )}
+    </p>
+  </div>
+)}
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(platform\)/dashboard/page.tsx
+git commit -m "feat(dashboard): show commission override promotion banner (#45)"
+```
+
+---
+
+### Task 6: CLI admin script
+
+**Files:**
+- Create: `src/scripts/creators-admin.ts`
+
+- [ ] **Step 1: Create the admin script**
+
+Create `src/scripts/creators-admin.ts`:
+
+```ts
+import "dotenv/config";
+import { db } from "../db";
+import { creators, products, orders } from "../db/schema";
+import { eq, or, ilike, isNotNull, count } from "drizzle-orm";
+import { isOverrideActive } from "../lib/commission";
+
+type Creator = typeof creators.$inferSelect;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function parseDuration(duration: string): Date | null {
+  const months: Record<string, number> = {
+    "3months": 3,
+    "6months": 6,
+    "12months": 12,
+  };
+  if (duration === "permanent") return null;
+  const m = months[duration];
+  if (!m) {
+    console.error(`Invalid duration: ${duration}. Use: 3months, 6months, 12months, permanent`);
+    process.exit(1);
+  }
+  const date = new Date();
+  date.setMonth(date.getMonth() + m);
+  return date;
+}
+
+function formatCreator(c: Creator): string {
+  const override = isOverrideActive(c.commissionOverridePercent, c.commissionOverrideExpiresAt)
+    ? `${c.commissionOverridePercent}% until ${c.commissionOverrideExpiresAt?.toLocaleDateString() ?? "permanent"}`
+    : "none";
+  return [
+    `  Name:       ${c.name}`,
+    `  Email:      ${c.email}`,
+    `  Slug:       ${c.slug}`,
+    `  Store:      ${c.storeName ?? "(no store name)"}`,
+    `  Stripe:     ${c.stripeConnectId ?? "(not connected)"}`,
+    `  Override:   ${override}`,
+    `  Created:    ${c.createdAt.toLocaleDateString()}`,
+  ].join("\n");
+}
+
+async function findCreator(query: string): Promise<Creator> {
+  const result = await db
+    .select()
+    .from(creators)
+    .where(
+      or(
+        eq(creators.email, query),
+        eq(creators.slug, query)
+      )
+    )
+    .then((rows) => rows[0]);
+
+  if (!result) {
+    console.error(`Creator not found: ${query}`);
+    process.exit(1);
+  }
+  return result;
+}
+
+// ─── Commands ───────────────────────────────────────────────────────────────
+
+async function cmdSearch(query: string) {
+  const results = await db
+    .select()
+    .from(creators)
+    .where(
+      or(
+        ilike(creators.name, `%${query}%`),
+        ilike(creators.email, `%${query}%`),
+        ilike(creators.slug, `%${query}%`)
+      )
+    );
+
+  if (results.length === 0) {
+    console.log("No creators found.");
+    return;
+  }
+
+  console.log(`Found ${results.length} creator(s):\n`);
+  for (const c of results) {
+    console.log(`- ${c.name} (${c.email}) — slug: ${c.slug}`);
+  }
+}
+
+async function cmdInfo(query: string) {
+  const c = await findCreator(query);
+
+  const [productCount] = await db
+    .select({ value: count() })
+    .from(products)
+    .where(eq(products.creatorId, c.id));
+
+  const [orderCount] = await db
+    .select({ value: count() })
+    .from(orders)
+    .where(eq(orders.creatorId, c.id));
+
+  console.log(`Creator: ${c.name}\n`);
+  console.log(formatCreator(c));
+  console.log(`  Products:   ${productCount.value}`);
+  console.log(`  Orders:     ${orderCount.value}`);
+}
+
+async function cmdSetCommission(query: string, percentStr: string, duration: string) {
+  const percent = parseInt(percentStr, 10);
+  if (isNaN(percent) || percent < 0 || percent > 100) {
+    console.error("Percent must be an integer between 0 and 100.");
+    process.exit(1);
+  }
+
+  const expiresAt = parseDuration(duration);
+  const c = await findCreator(query);
+
+  await db
+    .update(creators)
+    .set({
+      commissionOverridePercent: percent,
+      commissionOverrideExpiresAt: expiresAt,
+    })
+    .where(eq(creators.id, c.id));
+
+  const expiryLabel = expiresAt ? expiresAt.toLocaleDateString() : "permanent";
+  console.log(`Set ${percent}% commission for ${c.name} (${c.email}), expires: ${expiryLabel}`);
+}
+
+async function cmdRemoveCommission(query: string) {
+  const c = await findCreator(query);
+
+  await db
+    .update(creators)
+    .set({
+      commissionOverridePercent: null,
+      commissionOverrideExpiresAt: null,
+    })
+    .where(eq(creators.id, c.id));
+
+  console.log(`Removed commission override for ${c.name} (${c.email}). Back to default 5%.`);
+}
+
+async function cmdListOverrides() {
+  const results = await db
+    .select()
+    .from(creators)
+    .where(isNotNull(creators.commissionOverridePercent));
+
+  const active = results.filter(isActive);
+
+  if (active.length === 0) {
+    console.log("No active commission overrides.");
+    return;
+  }
+
+  console.log(`${active.length} active override(s):\n`);
+  for (const c of active) {
+    const expiry = c.commissionOverrideExpiresAt?.toLocaleDateString() ?? "permanent";
+    console.log(`- ${c.name} (${c.email}): ${c.commissionOverridePercent}% until ${expiry}`);
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+const [command, ...args] = process.argv.slice(2);
+
+const commands: Record<string, () => Promise<void>> = {
+  search: () => cmdSearch(args[0]),
+  info: () => cmdInfo(args[0]),
+  "set-commission": () => cmdSetCommission(args[0], args[1], args[2]),
+  "remove-commission": () => cmdRemoveCommission(args[0]),
+  "list-overrides": () => cmdListOverrides(),
+};
+
+if (!command || !commands[command]) {
+  console.log("Usage:");
+  console.log("  creators-admin search <query>");
+  console.log("  creators-admin info <email-or-slug>");
+  console.log("  creators-admin set-commission <email-or-slug> <percent> <duration>");
+  console.log("  creators-admin remove-commission <email-or-slug>");
+  console.log("  creators-admin list-overrides");
+  console.log("\nDurations: 3months, 6months, 12months, permanent");
+  process.exit(command ? 1 : 0);
+}
+
+commands[command]()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Error:", err);
+    process.exit(1);
+  });
+```
+
+- [ ] **Step 2: Add npm script**
+
+In `package.json`, add to `scripts`:
+
+```json
+"creators-admin": "tsx src/scripts/creators-admin.ts"
+```
+
+- [ ] **Step 3: Verify script runs**
+
+Run: `pnpm creators-admin`
+Expected: Prints usage help and exits with code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/scripts/creators-admin.ts package.json
+git commit -m "feat: add creators-admin CLI script (#45)"
+```
+
+---
+
+### Task 7: Claude Code /creators skill
+
+**Files:**
+- Create: `.claude/skills/creators/SKILL.md`
+
+- [ ] **Step 1: Create skill definition**
+
+Create `.claude/skills/creators/SKILL.md`:
+
+```markdown
+---
+name: creators
+description: Admin CLI for managing creators. Search, view details, set/remove commission overrides. Use when needing to manage creator accounts or early-bird promotions.
+---
+
+# Creators Admin
+
+Manage creator accounts and commission overrides via the CLI.
+
+**Arguments:** `$ARGUMENTS` contains the subcommand and arguments.
+
+## Commands
+
+### Search creators
+`/creators search <query>` — Search by name, email, or slug.
+
+Run: `pnpm creators-admin search <query>`
+
+### View creator details
+`/creators info <email-or-slug>` — Show full creator details including products, orders, and commission override status.
+
+Run: `pnpm creators-admin info <email-or-slug>`
+
+### Set commission override
+`/creators set-commission <email-or-slug> <percent> <duration>` — Set a commission override.
+
+- `percent`: 0-100 (0 = no commission)
+- `duration`: `3months`, `6months`, `12months`, or `permanent`
+
+Run: `pnpm creators-admin set-commission <email-or-slug> <percent> <duration>`
+
+### Remove commission override
+`/creators remove-commission <email-or-slug>` — Remove override, revert to default 5%.
+
+Run: `pnpm creators-admin remove-commission <email-or-slug>`
+
+### List active overrides
+`/creators list-overrides` — Show all creators with active commission overrides.
+
+Run: `pnpm creators-admin list-overrides`
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` to extract the subcommand and arguments. Examples:
+
+- `search alice` → `pnpm creators-admin search alice`
+- `set-commission alice@example.org 0 6months` → `pnpm creators-admin set-commission alice@example.org 0 6months`
+- `info bob-demo` → `pnpm creators-admin info bob-demo`
+
+If `$ARGUMENTS` is empty, run `pnpm creators-admin` to show usage help.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/creators/SKILL.md
+git commit -m "feat: add /creators Claude Code skill (#45)"
+```
+
+---
+
+### Task 8: Update seed data + final verification
+
+**Files:**
+- Modify: `src/scripts/seed.ts:45-63`
+
+- [ ] **Step 1: Add commission override to first seed creator**
+
+In `src/scripts/seed.ts`, update Alice's creator entry (first item in `seedCreators` array) to include:
+
+```ts
+commissionOverridePercent: 0,
+commissionOverrideExpiresAt: new Date("2026-09-15T00:00:00Z"),
+```
+
+This gives Alice a 0% override until September 15, 2026 for testing the dashboard banner.
+
+- [ ] **Step 2: Run build**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `pnpm test`
+Expected: All commission tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/scripts/seed.ts
+git commit -m "feat(seed): add commission override to seed creator for testing (#45)"
+```

--- a/docs/superpowers/specs/2026-03-15-commission-override-design.md
+++ b/docs/superpowers/specs/2026-03-15-commission-override-design.md
@@ -1,0 +1,76 @@
+# [GEN-020] Override 0% commissione per primi 50 creator
+
+**Issue:** #45
+**Date:** 2026-03-15
+**Status:** Approved
+
+## Context
+
+La strategia di lancio prevede "0% commissione per i primi 3/6 mesi" come incentivo per i primi 50 creator (seeding via DM outreach a creator Gumroad). Attualmente la commissione e' hardcoded al 5% in `lib/stripe.ts`. Non esiste un backoffice admin — la gestione avverra' tramite una CLI skill usabile direttamente da Claude Code.
+
+## Design
+
+### 1. Schema DB
+
+Due campi nuovi sulla tabella `creators`:
+
+- `commission_override_percent` (integer, nullable, range 0-100) — commissione override in percentuale (0 = zero commissione). `null` = usa il default 5%.
+- `commission_override_expires_at` (timestamp with timezone, nullable) — scadenza dell'override. `null` con override attivo = nessuna scadenza.
+
+**Validazione:** `commission_override_percent` deve essere nell'intervallo 0-100. Enforcement a livello di CLI script (non DB constraint, per semplicita').
+
+**Override attivo quando:** `commission_override_percent` IS NOT NULL AND (`commission_override_expires_at` IS NULL OR `commission_override_expires_at` > NOW()).
+
+### 2. Logica `calculatePlatformFee`
+
+Firma aggiornata (backward-compatible):
+
+```ts
+calculatePlatformFee(
+  amountCents: number,
+  creator?: {
+    commissionOverridePercent: number | null;
+    commissionOverrideExpiresAt: Date | null;
+  }
+): number
+```
+
+Logica:
+1. Se `creator` passato, `commissionOverridePercent` non null, e `commissionOverrideExpiresAt` nel futuro o null → usa `commissionOverridePercent`
+2. Altrimenti → 5% default
+
+Caller da aggiornare:
+- `src/app/api/checkout/route.ts` (riga 121) — passa il creator record (gia' disponibile in scope)
+- `src/app/api/stripe/webhook/route.ts` (riga 52) — serve aggiungere una query per fetchare il creator record (attualmente ha solo `creatorId` dal metadata)
+
+**Nota sul webhook:** Il fee reale addebitato da Stripe e' quello calcolato al checkout (via `application_fee_amount`). Il webhook ricalcola indipendentemente per salvare `platformFeeCents` nell'ordine. Con override time-sensitive, potrebbe esserci divergenza se l'override scade tra checkout e webhook. Soluzione: nel webhook, leggere `application_fee_amount` direttamente dalla Stripe session invece di ricalcolare. Questo elimina la possibilita' di mismatch.
+
+### 3. Dashboard — Banner promozione
+
+Banner informativo nella dashboard del creator (sopra le quick actions) visibile solo quando l'override e' attivo:
+
+> **0% commission** — Your early-bird promotion is active until September 15, 2026
+
+Nessuna azione richiesta dal creator. Inline nella dashboard page, nessun componente separato.
+
+### 4. CLI — Skill `/creators`
+
+Skill Claude Code per gestione admin creator con focus su commission override.
+
+**Comandi:**
+- `/creators search <query>` — cerca per nome, email o slug
+- `/creators info <email-or-slug>` — dettagli completi (nome, store, Stripe status, prodotti count, ordini count, override attivo)
+- `/creators set-commission <email-or-slug> <percent> <duration>` — setta override (durate: `3months`, `6months`, `12months`, `permanent`)
+- `/creators remove-commission <email-or-slug>` — rimuove override (setta entrambi i campi a null)
+- `/creators list-overrides` — tutti i creator con override attivo
+
+**Implementazione:** script Node.js `src/scripts/creators-admin.ts` che si connette al DB direttamente (usa `dotenv/config` e il client DB condiviso da `src/db/index.ts`, come `seed.ts`). La skill lo invoca via Bash con i parametri appropriati. Supporta `DATABASE_URL` env override per uso in produzione.
+
+**Migrazione:** `pnpm drizzle-kit generate` + `pnpm drizzle-kit push`. Colonne nullable, quindi non-destructive e non richiede default.
+
+## Out of scope
+
+- Admin dashboard web
+- MCP server admin
+- CRUD completo creator (modifica nome/slug, cancellazione)
+- Enforcement automatico del cap 50 creator

--- a/drizzle/0003_sweet_the_captain.sql
+++ b/drizzle/0003_sweet_the_captain.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "api_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"creator_id" uuid,
+	"key_hash" text NOT NULL,
+	"key_prefix" text NOT NULL,
+	"name" text NOT NULL,
+	"scopes" text[] NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "referral_conversions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"referral_id" uuid NOT NULL,
+	"order_id" uuid NOT NULL,
+	"commission_cents" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "referral_conversions_order_id_unique" UNIQUE("order_id")
+);
+--> statement-breakpoint
+CREATE TABLE "referrals" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"creator_id" uuid NOT NULL,
+	"code" text NOT NULL,
+	"affiliate_name" text NOT NULL,
+	"affiliate_email" text,
+	"product_id" uuid,
+	"commission_percent" integer NOT NULL,
+	"click_count" integer DEFAULT 0 NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "referrals_creator_id_code_unique" UNIQUE("creator_id","code")
+);
+--> statement-breakpoint
+ALTER TABLE "creators" ADD COLUMN "commission_override_percent" integer;--> statement-breakpoint
+ALTER TABLE "creators" ADD COLUMN "commission_override_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_creator_id_creators_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."creators"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "referral_conversions" ADD CONSTRAINT "referral_conversions_referral_id_referrals_id_fk" FOREIGN KEY ("referral_id") REFERENCES "public"."referrals"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "referral_conversions" ADD CONSTRAINT "referral_conversions_order_id_orders_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."orders"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "referrals" ADD CONSTRAINT "referrals_creator_id_creators_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."creators"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "referrals" ADD CONSTRAINT "referrals_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1346 @@
+{
+  "id": "467d2a6a-e4dd-4691-a2f8-cc497a3bcf10",
+  "prevId": "360c3b1d-f346-4a5e-9e18-19834f4beac4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_creator_id_creators_id_fk": {
+          "name": "api_keys_creator_id_creators_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticator": {
+      "name": "authenticator",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "name": "authenticator_userId_credentialID_pk",
+          "columns": [
+            "userId",
+            "credentialID"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.buy_intents": {
+      "name": "buy_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "buy_intents_product_id_products_id_fk": {
+          "name": "buy_intents_product_id_products_id_fk",
+          "tableFrom": "buy_intents",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "buy_intents_creator_id_creators_id_fk": {
+          "name": "buy_intents_creator_id_creators_id_fk",
+          "tableFrom": "buy_intents",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coupons": {
+      "name": "coupons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "discount_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_amount_cents": {
+          "name": "min_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redemption_count": {
+          "name": "redemption_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_creator_id_creators_id_fk": {
+          "name": "coupons_creator_id_creators_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "coupons_product_id_products_id_fk": {
+          "name": "coupons_product_id_products_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "coupons_creator_id_code_unique": {
+          "name": "coupons_creator_id_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.creators": {
+      "name": "creators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_connect_id": {
+          "name": "stripe_connect_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_name": {
+          "name": "store_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_description": {
+          "name": "store_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_theme": {
+          "name": "store_theme",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_override_percent": {
+          "name": "commission_override_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_override_expires_at": {
+          "name": "commission_override_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "creators_user_id_user_id_fk": {
+          "name": "creators_user_id_user_id_fk",
+          "tableFrom": "creators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "creators_user_id_unique": {
+          "name": "creators_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "creators_slug_unique": {
+          "name": "creators_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.download_tokens": {
+      "name": "download_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "download_tokens_order_id_orders_id_fk": {
+          "name": "download_tokens_order_id_orders_id_fk",
+          "tableFrom": "download_tokens",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "download_tokens_token_unique": {
+          "name": "download_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_email": {
+          "name": "buyer_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyer_name": {
+          "name": "buyer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_product_id_products_id_fk": {
+          "name": "orders_product_id_products_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_creator_id_creators_id_fk": {
+          "name": "orders_creator_id_creators_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_coupon_id_coupons_id_fk": {
+          "name": "orders_coupon_id_coupons_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_stripe_payment_intent_id_unique": {
+          "name": "orders_stripe_payment_intent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_payment_intent_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_views": {
+      "name": "page_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_slug": {
+          "name": "store_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_views_product_id_products_id_fk": {
+          "name": "page_views_product_id_products_id_fk",
+          "tableFrom": "page_views",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "products_creator_id_creators_id_fk": {
+          "name": "products_creator_id_creators_id_fk",
+          "tableFrom": "products",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_conversions": {
+      "name": "referral_conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commission_cents": {
+          "name": "commission_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referral_conversions_referral_id_referrals_id_fk": {
+          "name": "referral_conversions_referral_id_referrals_id_fk",
+          "tableFrom": "referral_conversions",
+          "tableTo": "referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "referral_conversions_order_id_orders_id_fk": {
+          "name": "referral_conversions_order_id_orders_id_fk",
+          "tableFrom": "referral_conversions",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referral_conversions_order_id_unique": {
+          "name": "referral_conversions_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referrals": {
+      "name": "referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliate_name": {
+          "name": "affiliate_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliate_email": {
+          "name": "affiliate_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_percent": {
+          "name": "commission_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "click_count": {
+          "name": "click_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "referrals_creator_id_creators_id_fk": {
+          "name": "referrals_creator_id_creators_id_fk",
+          "tableFrom": "referrals",
+          "tableTo": "creators",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "referrals_product_id_products_id_fk": {
+          "name": "referrals_product_id_products_id_fk",
+          "tableFrom": "referrals",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "referrals_creator_id_code_unique": {
+          "name": "referrals_creator_id_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "creator_id",
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.discount_type": {
+      "name": "discount_type",
+      "schema": "public",
+      "values": [
+        "percentage",
+        "fixed"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "refunded"
+      ]
+    },
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773249079591,
       "tag": "0002_sudden_baron_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1773593505389,
+      "tag": "0003_sweet_the_captain",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "eslint",
     "seed": "tsx src/scripts/seed.ts",
     "smoke": "vitest run --config vitest.config.smoke.ts",
-    "generate-api-key": "tsx src/scripts/generate-api-key.ts"
+    "generate-api-key": "tsx src/scripts/generate-api-key.ts",
+    "creators-admin": "tsx src/scripts/creators-admin.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/src/app/(platform)/dashboard/page.tsx
+++ b/src/app/(platform)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { StripeCTA } from "@/components/stripe-cta";
 import { StripeToast } from "@/components/stripe-toast";
 import { DashboardAnalytics } from "@/components/dashboard/dashboard-analytics";
+import { isOverrideActive } from "@/lib/commission";
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -22,6 +23,11 @@ export default async function DashboardPage() {
     .then((rows) => rows[0]);
 
   if (!creator) redirect("/onboarding");
+
+  const hasActivePromotion = isOverrideActive(
+    creator.commissionOverridePercent,
+    creator.commissionOverrideExpiresAt
+  );
 
   const stripeCheckPromise = creator.stripeConnectId
     ? import("@/lib/stripe")
@@ -72,6 +78,30 @@ export default async function DashboardPage() {
       {!stripeReady && (
         <div className="mt-8 animate-fade-up stagger-4">
           <StripeCTA creatorId={creator.id} />
+        </div>
+      )}
+
+      {/* Commission override banner */}
+      {hasActivePromotion && (
+        <div className="mt-8 bg-green-50 border border-green-200 rounded-xl px-5 py-4 animate-fade-up stagger-4">
+          <p className="text-green-800 font-semibold">
+            {creator.commissionOverridePercent}% commission
+            {creator.commissionOverrideExpiresAt && (
+              <span className="font-normal text-green-700">
+                {" "}— Your early-bird promotion is active until{" "}
+                {new Date(creator.commissionOverrideExpiresAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </span>
+            )}
+            {!creator.commissionOverrideExpiresAt && (
+              <span className="font-normal text-green-700">
+                {" "}— Your promotional rate is permanently active
+              </span>
+            )}
+          </p>
         </div>
       )}
 

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -118,7 +118,7 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const platformFee = calculatePlatformFee(finalPriceCents);
+  const platformFee = calculatePlatformFee(finalPriceCents, creator);
 
   try {
     const checkoutSession = await getStripe().checkout.sessions.create({

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { getStripe, calculatePlatformFee } from "@/lib/stripe";
+import { getStripe } from "@/lib/stripe";
 import { db } from "@/db";
 import { orders, downloadTokens, products, creators, referrals, referralConversions } from "@/db/schema";
 import { sendPurchaseConfirmation } from "@/lib/email";
@@ -40,6 +40,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ received: true });
     }
 
+    // Read the actual application fee from Stripe (authoritative, set at checkout time)
+    const paymentIntent = await getStripe().paymentIntents.retrieve(
+      session.payment_intent as string
+    );
+    const actualPlatformFee = paymentIntent.application_fee_amount ?? 0;
+
     try {
       // Existing transaction — capture order
       const [order] = await db.transaction(async (tx) => {
@@ -49,7 +55,7 @@ export async function POST(req: NextRequest) {
           buyerEmail: session.customer_details?.email ?? "unknown",
           buyerName: session.customer_details?.name,
           amountCents: session.amount_total!,
-          platformFeeCents: calculatePlatformFee(session.amount_total!),
+          platformFeeCents: actualPlatformFee,
           stripePaymentIntentId: session.payment_intent as string,
           couponId: couponId || null,
           status: "completed",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -143,6 +143,8 @@ export const creators = pgTable("creators", {
   storeName: text("store_name"),
   storeDescription: text("store_description"),
   storeTheme: jsonb("store_theme").$type<StoreTheme>(),
+  commissionOverridePercent: integer("commission_override_percent"),
+  commissionOverrideExpiresAt: timestamp("commission_override_expires_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .defaultNow()
     .notNull(),

--- a/src/lib/__tests__/commission.test.ts
+++ b/src/lib/__tests__/commission.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isOverrideActive, getEffectiveCommissionPercent } from "../commission";
+
+describe("isOverrideActive", () => {
+  it("returns false when override percent is null", () => {
+    expect(isOverrideActive(null, null)).toBe(false);
+  });
+
+  it("returns true when override is set with no expiry", () => {
+    expect(isOverrideActive(0, null)).toBe(true);
+  });
+
+  it("returns true when override is set and expiry is in the future", () => {
+    const future = new Date(Date.now() + 86400000);
+    expect(isOverrideActive(0, future)).toBe(true);
+  });
+
+  it("returns false when override is set but expired", () => {
+    const past = new Date(Date.now() - 86400000);
+    expect(isOverrideActive(0, past)).toBe(false);
+  });
+
+  it("returns true for non-zero override percent", () => {
+    expect(isOverrideActive(3, null)).toBe(true);
+  });
+});
+
+describe("getEffectiveCommissionPercent", () => {
+  it("returns default 5 when no creator provided", () => {
+    expect(getEffectiveCommissionPercent()).toBe(5);
+  });
+
+  it("returns default 5 when override is null", () => {
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: null,
+      commissionOverrideExpiresAt: null,
+    })).toBe(5);
+  });
+
+  it("returns 0 when active 0% override", () => {
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 0,
+      commissionOverrideExpiresAt: null,
+    })).toBe(0);
+  });
+
+  it("returns default 5 when override is expired", () => {
+    const past = new Date(Date.now() - 86400000);
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 0,
+      commissionOverrideExpiresAt: past,
+    })).toBe(5);
+  });
+
+  it("returns custom percent when active", () => {
+    const future = new Date(Date.now() + 86400000);
+    expect(getEffectiveCommissionPercent({
+      commissionOverridePercent: 2,
+      commissionOverrideExpiresAt: future,
+    })).toBe(2);
+  });
+});

--- a/src/lib/commission.ts
+++ b/src/lib/commission.ts
@@ -1,0 +1,25 @@
+const DEFAULT_COMMISSION_PERCENT = 5;
+
+export type CommissionOverride = {
+  commissionOverridePercent: number | null;
+  commissionOverrideExpiresAt: Date | null;
+};
+
+export function isOverrideActive(
+  percent: number | null,
+  expiresAt: Date | null
+): boolean {
+  if (percent === null) return false;
+  if (expiresAt === null) return true;
+  return expiresAt > new Date();
+}
+
+export function getEffectiveCommissionPercent(
+  creator?: CommissionOverride
+): number {
+  if (!creator) return DEFAULT_COMMISSION_PERCENT;
+  if (isOverrideActive(creator.commissionOverridePercent, creator.commissionOverrideExpiresAt)) {
+    return creator.commissionOverridePercent!;
+  }
+  return DEFAULT_COMMISSION_PERCENT;
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,4 +1,5 @@
 import Stripe from "stripe";
+import { getEffectiveCommissionPercent, type CommissionOverride } from "./commission";
 
 let _stripe: Stripe | null = null;
 
@@ -11,8 +12,10 @@ export function getStripe(): Stripe {
   return _stripe;
 }
 
-const PLATFORM_FEE_PERCENT = 5;
-
-export function calculatePlatformFee(amountCents: number): number {
-  return Math.round((amountCents * PLATFORM_FEE_PERCENT) / 100);
+export function calculatePlatformFee(
+  amountCents: number,
+  creator?: CommissionOverride
+): number {
+  const percent = getEffectiveCommissionPercent(creator);
+  return Math.round((amountCents * percent) / 100);
 }

--- a/src/scripts/creators-admin.ts
+++ b/src/scripts/creators-admin.ts
@@ -1,0 +1,190 @@
+import "dotenv/config";
+import { db } from "../db";
+import { creators, products, orders } from "../db/schema";
+import { eq, or, ilike, isNotNull, count } from "drizzle-orm";
+import { isOverrideActive } from "../lib/commission";
+
+type Creator = typeof creators.$inferSelect;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function parseDuration(duration: string): Date | null {
+  const months: Record<string, number> = {
+    "3months": 3,
+    "6months": 6,
+    "12months": 12,
+  };
+  if (duration === "permanent") return null;
+  const m = months[duration];
+  if (!m) {
+    console.error(`Invalid duration: ${duration}. Use: 3months, 6months, 12months, permanent`);
+    process.exit(1);
+  }
+  const date = new Date();
+  date.setMonth(date.getMonth() + m);
+  return date;
+}
+
+function formatCreator(c: Creator): string {
+  const override = isOverrideActive(c.commissionOverridePercent, c.commissionOverrideExpiresAt)
+    ? `${c.commissionOverridePercent}% until ${c.commissionOverrideExpiresAt?.toLocaleDateString() ?? "permanent"}`
+    : "none";
+  return [
+    `  Name:       ${c.name}`,
+    `  Email:      ${c.email}`,
+    `  Slug:       ${c.slug}`,
+    `  Store:      ${c.storeName ?? "(no store name)"}`,
+    `  Stripe:     ${c.stripeConnectId ?? "(not connected)"}`,
+    `  Override:   ${override}`,
+    `  Created:    ${c.createdAt.toLocaleDateString()}`,
+  ].join("\n");
+}
+
+async function findCreator(query: string): Promise<Creator> {
+  const result = await db
+    .select()
+    .from(creators)
+    .where(
+      or(
+        eq(creators.email, query),
+        eq(creators.slug, query)
+      )
+    )
+    .then((rows) => rows[0]);
+
+  if (!result) {
+    console.error(`Creator not found: ${query}`);
+    process.exit(1);
+  }
+  return result;
+}
+
+// ─── Commands ───────────────────────────────────────────────────────────────
+
+async function cmdSearch(query: string) {
+  const results = await db
+    .select()
+    .from(creators)
+    .where(
+      or(
+        ilike(creators.name, `%${query}%`),
+        ilike(creators.email, `%${query}%`),
+        ilike(creators.slug, `%${query}%`)
+      )
+    );
+
+  if (results.length === 0) {
+    console.log("No creators found.");
+    return;
+  }
+
+  console.log(`Found ${results.length} creator(s):\n`);
+  for (const c of results) {
+    console.log(`- ${c.name} (${c.email}) — slug: ${c.slug}`);
+  }
+}
+
+async function cmdInfo(query: string) {
+  const c = await findCreator(query);
+
+  const [productCount] = await db
+    .select({ value: count() })
+    .from(products)
+    .where(eq(products.creatorId, c.id));
+
+  const [orderCount] = await db
+    .select({ value: count() })
+    .from(orders)
+    .where(eq(orders.creatorId, c.id));
+
+  console.log(`Creator: ${c.name}\n`);
+  console.log(formatCreator(c));
+  console.log(`  Products:   ${productCount.value}`);
+  console.log(`  Orders:     ${orderCount.value}`);
+}
+
+async function cmdSetCommission(query: string, percentStr: string, duration: string) {
+  const percent = parseInt(percentStr, 10);
+  if (isNaN(percent) || percent < 0 || percent > 100) {
+    console.error("Percent must be an integer between 0 and 100.");
+    process.exit(1);
+  }
+
+  const expiresAt = parseDuration(duration);
+  const c = await findCreator(query);
+
+  await db
+    .update(creators)
+    .set({
+      commissionOverridePercent: percent,
+      commissionOverrideExpiresAt: expiresAt,
+    })
+    .where(eq(creators.id, c.id));
+
+  const expiryLabel = expiresAt ? expiresAt.toLocaleDateString() : "permanent";
+  console.log(`Set ${percent}% commission for ${c.name} (${c.email}), expires: ${expiryLabel}`);
+}
+
+async function cmdRemoveCommission(query: string) {
+  const c = await findCreator(query);
+
+  await db
+    .update(creators)
+    .set({
+      commissionOverridePercent: null,
+      commissionOverrideExpiresAt: null,
+    })
+    .where(eq(creators.id, c.id));
+
+  console.log(`Removed commission override for ${c.name} (${c.email}). Back to default 5%.`);
+}
+
+async function cmdListOverrides() {
+  const results = await db
+    .select()
+    .from(creators)
+    .where(isNotNull(creators.commissionOverridePercent));
+
+  const active = results.filter((c) => isOverrideActive(c.commissionOverridePercent, c.commissionOverrideExpiresAt));
+
+  if (active.length === 0) {
+    console.log("No active commission overrides.");
+    return;
+  }
+
+  console.log(`${active.length} active override(s):\n`);
+  for (const c of active) {
+    const expiry = c.commissionOverrideExpiresAt?.toLocaleDateString() ?? "permanent";
+    console.log(`- ${c.name} (${c.email}): ${c.commissionOverridePercent}% until ${expiry}`);
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+const [command, ...args] = process.argv.slice(2);
+
+const commands: Record<string, () => Promise<void>> = {
+  search: () => cmdSearch(args[0]),
+  info: () => cmdInfo(args[0]),
+  "set-commission": () => cmdSetCommission(args[0], args[1], args[2]),
+  "remove-commission": () => cmdRemoveCommission(args[0]),
+  "list-overrides": () => cmdListOverrides(),
+};
+
+if (!command || !commands[command]) {
+  console.log("Usage:");
+  console.log("  creators-admin search <query>");
+  console.log("  creators-admin info <email-or-slug>");
+  console.log("  creators-admin set-commission <email-or-slug> <percent> <duration>");
+  console.log("  creators-admin remove-commission <email-or-slug>");
+  console.log("  creators-admin list-overrides");
+  console.log("\nDurations: 3months, 6months, 12months, permanent");
+  process.exit(command ? 1 : 0);
+}
+
+commands[command]()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Error:", err);
+    process.exit(1);
+  });

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -37,16 +37,16 @@ const ORDER_IDS = [
 // ─── Seed data ──────────────────────────────────────────────────────────────
 
 const seedUsers = [
-  { id: USER_IDS[0], name: "Alice Demo", email: "alice@demo.test" },
-  { id: USER_IDS[1], name: "Bob Demo", email: "bob@demo.test" },
-  { id: USER_IDS[2], name: "Carol Demo", email: "carol@demo.test" },
+  { id: USER_IDS[0], name: "Alice Demo", email: "alice@example.org" },
+  { id: USER_IDS[1], name: "Bob Demo", email: "bob@example.org" },
+  { id: USER_IDS[2], name: "Carol Demo", email: "carol@example.org" },
 ];
 
 const seedCreators = [
   {
     id: CREATOR_IDS[0],
     userId: USER_IDS[0],
-    email: "alice@demo.test",
+    email: "alice@example.org",
     name: "Alice Demo",
     slug: "alice-demo",
     storeName: "Alice's Digital Shop",
@@ -61,11 +61,13 @@ const seedCreators = [
       heroStyle: "gradient" as const,
       layout: "grid" as const,
     },
+    commissionOverridePercent: 0,
+    commissionOverrideExpiresAt: new Date("2026-09-15T00:00:00Z"),
   },
   {
     id: CREATOR_IDS[1],
     userId: USER_IDS[1],
-    email: "bob@demo.test",
+    email: "bob@example.org",
     name: "Bob Demo",
     slug: "bob-demo",
     storeName: "Bob's Creative Hub",
@@ -84,7 +86,7 @@ const seedCreators = [
   {
     id: CREATOR_IDS[2],
     userId: USER_IDS[2],
-    email: "carol@demo.test",
+    email: "carol@example.org",
     name: "Carol Demo",
     slug: "carol-demo",
     storeName: "Carol's Template Studio",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
Promotes staging to production.

Related: https://github.com/tatanka/fooshop/pull/61
Closes #45

## Summary
- Commission override system for early-bird creators (0% fee for defined period)
- CLI management via `pnpm creators-admin` and `/creators` skill
- Dashboard promotion banner
- Webhook reads authoritative fee from Stripe payment intent