### PR TITLE
fix: convert ISO string to Date for commission PATCH

### DIFF
--- a/src/app/api/admin/creators/[id]/route.ts
+++ b/src/app/api/admin/creators/[id]/route.ts
@@ -53,7 +53,9 @@ export async function PATCH(
   if (body.commissionOverridePercent !== undefined)
     allowedFields.commissionOverridePercent = body.commissionOverridePercent;
   if (body.commissionOverrideExpiresAt !== undefined)
-    allowedFields.commissionOverrideExpiresAt = body.commissionOverrideExpiresAt;
+    allowedFields.commissionOverrideExpiresAt = body.commissionOverrideExpiresAt
+      ? new Date(body.commissionOverrideExpiresAt)
+      : null;
 
   if (Object.keys(allowedFields).length === 0) {
     return NextResponse.json(


### PR DESCRIPTION
Fix 500 on commission override PATCH — Drizzle needs Date objects for timestamps.