### PR TITLE
[Issue #51] Simplify validation schemas

### DIFF
--- a/src/app/api/referrals/[id]/route.ts
+++ b/src/app/api/referrals/[id]/route.ts
@@ -34,7 +34,7 @@ export async function PUT(req: NextRequest, { params }: Props) {
 
   const allowedFields: Record<string, unknown> = {};
   if (result.data.affiliateName !== undefined) allowedFields.affiliateName = result.data.affiliateName;
-  if (result.data.affiliateEmail !== undefined) allowedFields.affiliateEmail = result.data.affiliateEmail;
+  if (result.data.affiliateEmail !== undefined) allowedFields.affiliateEmail = result.data.affiliateEmail?.trim() || null;
   if (result.data.commissionPercent !== undefined) allowedFields.commissionPercent = result.data.commissionPercent;
   if (result.data.active !== undefined) allowedFields.active = result.data.active;
   if (result.data.productId !== undefined) {

--- a/src/lib/validations/__tests__/products.test.ts
+++ b/src/lib/validations/__tests__/products.test.ts
@@ -15,7 +15,7 @@ describe("productCreateSchema", () => {
       title: "My Product",
       description: "A description",
       priceCents: 999,
-      category: "ebook",
+      category: "templates",
       status: "published",
       fileUrl: "https://example.com/file.pdf",
       coverImageUrl: "https://example.com/cover.jpg",
@@ -68,6 +68,15 @@ describe("productCreateSchema", () => {
       title: "My Product",
       priceCents: 999,
       fileUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid category", () => {
+    const result = productCreateSchema.safeParse({
+      title: "My Product",
+      priceCents: 999,
+      category: "invalid-category",
     });
     expect(result.success).toBe(false);
   });

--- a/src/lib/validations/admin.ts
+++ b/src/lib/validations/admin.ts
@@ -1,31 +1,22 @@
 import { z } from "zod";
-import { uuidSchema } from "./common";
+import { uuidSchema, storeNameSchema, storeDescriptionSchema, atLeastOneField } from "./common";
+import { baseCouponSchema } from "./coupons";
 
-export const adminCouponCreateSchema = z.object({
-  creatorId: uuidSchema,
-  code: z.string().min(1).max(50).optional(),
-  discountType: z.enum(["percentage", "fixed"]),
-  discountValue: z.number().int().positive(),
-  productId: uuidSchema.optional(),
-  minAmountCents: z.number().int().min(0).optional(),
-  maxRedemptions: z.number().int().positive().optional(),
-  expiresAt: z.string().datetime().optional(),
-}).refine(
-  (d) => !(d.discountType === "percentage" && (d.discountValue < 1 || d.discountValue > 100)),
-  { message: "Percentage discount must be between 1 and 100", path: ["discountValue"] }
-);
+export const adminCouponCreateSchema = baseCouponSchema
+  .extend({ creatorId: uuidSchema })
+  .refine(
+    (d) => !(d.discountType === "percentage" && (d.discountValue < 1 || d.discountValue > 100)),
+    { message: "Percentage discount must be between 1 and 100", path: ["discountValue"] }
+  );
 
 export const adminCreatorUpdateSchema = z.object({
   name: z.string().min(1).optional(),
   email: z.string().email().optional(),
-  storeName: z.string().min(1).max(100).optional(),
-  storeDescription: z.string().max(2000).optional(),
+  storeName: storeNameSchema.optional(),
+  storeDescription: storeDescriptionSchema.optional(),
   commissionOverridePercent: z.number().int().min(0).max(100).nullable().optional(),
   commissionOverrideExpiresAt: z.string().datetime().nullable().optional(),
-}).refine(
-  (obj) => Object.values(obj).some((v) => v !== undefined),
-  { message: "At least one field is required" }
-);
+}).refine(atLeastOneField.refine, { message: atLeastOneField.message });
 
 export type AdminCouponCreate = z.infer<typeof adminCouponCreateSchema>;
 export type AdminCreatorUpdate = z.infer<typeof adminCreatorUpdateSchema>;

--- a/src/lib/validations/common.ts
+++ b/src/lib/validations/common.ts
@@ -3,3 +3,11 @@ import { z } from "zod";
 export const uuidSchema = z.string().uuid();
 export const priceCentsSchema = z.number().int().min(0);
 export const hexColorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/);
+
+export const storeNameSchema = z.string().min(1).max(100);
+export const storeDescriptionSchema = z.string().max(2000);
+
+export const atLeastOneField = {
+  refine: (obj: Record<string, unknown>) => Object.values(obj).some((v) => v !== undefined),
+  message: "At least one field is required",
+} as const;

--- a/src/lib/validations/coupons.ts
+++ b/src/lib/validations/coupons.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { uuidSchema } from "./common";
+import { uuidSchema, atLeastOneField } from "./common";
 
-const baseCouponSchema = z.object({
+export const baseCouponSchema = z.object({
   code: z.string().min(1).max(50).optional(),
   discountType: z.enum(["percentage", "fixed"]),
   discountValue: z.number().int().positive(),
@@ -21,10 +21,7 @@ export const couponUpdateSchema = z.object({
   maxRedemptions: z.number().int().positive().nullable().optional(),
   expiresAt: z.string().datetime().nullable().optional(),
   minAmountCents: z.number().int().min(0).nullable().optional(),
-}).refine(
-  (obj) => Object.values(obj).some((v) => v !== undefined),
-  { message: "At least one field is required" }
-);
+}).refine(atLeastOneField.refine, { message: atLeastOneField.message });
 
 export const couponValidateSchema = z.object({
   code: z.string().min(1),

--- a/src/lib/validations/products.ts
+++ b/src/lib/validations/products.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 import { priceCentsSchema } from "./common";
+import { CATEGORIES } from "@/lib/categories";
 
 export const productCreateSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(5000).optional(),
   priceCents: priceCentsSchema,
-  category: z.string().min(1).optional(),
+  category: z.enum(CATEGORIES).optional(),
   status: z.enum(["draft", "published"]).optional(),
   fileUrl: z.string().url().optional(),
   coverImageUrl: z.string().url().optional(),

--- a/src/lib/validations/referrals.ts
+++ b/src/lib/validations/referrals.ts
@@ -1,24 +1,21 @@
 import { z } from "zod";
-import { uuidSchema } from "./common";
+import { uuidSchema, atLeastOneField } from "./common";
 
 export const referralCreateSchema = z.object({
   code: z.string().min(1).max(50).optional(),
-  affiliateName: z.string().min(1).max(200),
+  affiliateName: z.string().min(1).max(200).transform((s) => s.trim()),
   affiliateEmail: z.string().email().optional(),
   productId: uuidSchema.optional(),
   commissionPercent: z.number().int().min(1).max(100),
 });
 
 export const referralUpdateSchema = z.object({
-  affiliateName: z.string().min(1).max(200).optional(),
+  affiliateName: z.string().min(1).max(200).transform((s) => s.trim()).optional(),
   affiliateEmail: z.string().email().nullable().optional(),
   commissionPercent: z.number().int().min(1).max(100).optional(),
   active: z.boolean().optional(),
   productId: uuidSchema.nullable().optional(),
-}).refine(
-  (obj) => Object.values(obj).some((v) => v !== undefined),
-  { message: "At least one field is required" }
-);
+}).refine(atLeastOneField.refine, { message: atLeastOneField.message });
 
 export type ReferralCreate = z.infer<typeof referralCreateSchema>;
 export type ReferralUpdate = z.infer<typeof referralUpdateSchema>;

--- a/src/lib/validations/store.ts
+++ b/src/lib/validations/store.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { hexColorSchema } from "./common";
+import { hexColorSchema, storeNameSchema, storeDescriptionSchema } from "./common";
 
 export const storeUpdateSchema = z.object({
-  storeName: z.string().min(1).max(100).optional(),
-  storeDescription: z.string().max(2000).optional(),
+  storeName: storeNameSchema.optional(),
+  storeDescription: storeDescriptionSchema.optional(),
 });
 
 export const themeSchema = z.object({


### PR DESCRIPTION
Follow-up to #72 — code quality improvements from review.

## Summary
- Deduplicate baseCouponSchema (export + extend in admin.ts)
- Extract atLeastOneField refine to common.ts (was repeated 3x)
- Share storeName/storeDescription constraints between store.ts and admin.ts
- Fix .trim() regression on referral affiliateName/affiliateEmail
- Use CATEGORIES enum for product category validation