### PR TITLE
fix: native script tags for Plausible verification

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Playfair_Display, DM_Sans } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 
 const playfair = Playfair_Display({
@@ -28,23 +27,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${playfair.variable} ${dmSans.variable} antialiased`}
-      >
-        {children}
-        <Script
+      <head>
+        <script
           defer
           data-domain="fooshop.exelab.net"
           src="https://plausible.io/js/pa-erOyM4okq0LymrFvoE4.js"
-          strategy="afterInteractive"
         />
-        <Script
-          id="plausible-init"
-          strategy="afterInteractive"
+        <script
           dangerouslySetInnerHTML={{
             __html: `window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)};plausible.init=plausible.init||function(){(plausible.o=[])}; plausible.init()`,
           }}
         />
+      </head>
+      <body
+        className={`${playfair.variable} ${dmSans.variable} antialiased`}
+      >
+        {children}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Replace next/script with native `<script>` tags so Plausible's verification bot can detect the snippet in the initial HTML