### PR TITLE
[Issue #81] CLI: package setup + auth flow (fooshop login)

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "fooshop",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Fooshop CLI — commerce from your terminal",
+  "main": "dist/index.js",
+  "bin": {
+    "fooshop": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": ["dist"],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "commander": "^13.0.0",
+    "open": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5",
+    "vitest": "^2.1.9"
+  }
+}

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -1,0 +1,993 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
+      open:
+        specifier: ^10.0.0
+        version: 10.2.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.37
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.37)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.37))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.37)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  commander@13.1.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  is-docker@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  run-applescript@7.1.0: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@20.19.37):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.37)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.37):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.37):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.37))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.37)
+      vite-node: 2.1.9(@types/node@20.19.37)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readConfig, writeConfig, getApiKey, getBaseUrl } from "../lib/config.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// Use a temp dir to avoid touching real ~/.fooshop
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("readConfig", () => {
+  it("returns null when config file does not exist", () => {
+    expect(readConfig()).toBeNull();
+  });
+
+  it("reads existing config file", () => {
+    const config = { apiKey: "fsk_test123", baseUrl: "https://fooshop.ai", email: "test@example.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(readConfig()).toEqual(config);
+  });
+
+  it("returns null for malformed JSON", () => {
+    fs.writeFileSync(path.join(tmpDir, "config.json"), "not json");
+    expect(readConfig()).toBeNull();
+  });
+});
+
+describe("writeConfig", () => {
+  it("creates directory and writes config", () => {
+    const nestedDir = path.join(tmpDir, "nested");
+    vi.stubEnv("FOOSHOP_CONFIG_DIR", nestedDir);
+    writeConfig({ apiKey: "fsk_abc", baseUrl: "https://fooshop.ai", email: "a@b.com" });
+    const content = JSON.parse(fs.readFileSync(path.join(nestedDir, "config.json"), "utf-8"));
+    expect(content.apiKey).toBe("fsk_abc");
+  });
+});
+
+describe("getApiKey", () => {
+  it("returns env var over config file", () => {
+    vi.stubEnv("FOOSHOP_API_KEY", "fsk_from_env");
+    const config = { apiKey: "fsk_from_file", baseUrl: "https://fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getApiKey()).toBe("fsk_from_env");
+  });
+
+  it("returns config file value when env not set", () => {
+    const config = { apiKey: "fsk_from_file", baseUrl: "https://fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getApiKey()).toBe("fsk_from_file");
+  });
+
+  it("returns null when nothing is set", () => {
+    expect(getApiKey()).toBeNull();
+  });
+});
+
+describe("getBaseUrl", () => {
+  it("returns env var over config file", () => {
+    vi.stubEnv("FOOSHOP_BASE_URL", "https://staging.fooshop.ai");
+    expect(getBaseUrl()).toBe("https://staging.fooshop.ai");
+  });
+
+  it("returns config value when env not set", () => {
+    const config = { apiKey: "fsk_x", baseUrl: "https://custom.fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getBaseUrl()).toBe("https://custom.fooshop.ai");
+  });
+
+  it("returns default when nothing is set", () => {
+    expect(getBaseUrl()).toBe("https://fooshop.ai");
+  });
+});

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import http from "http";
+
+// Mock the open module before any imports that use it
+vi.mock("open", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { readConfig } from "../lib/config.js";
+import open from "open";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("login command", () => {
+  it("opens browser, receives callback, saves config", async () => {
+    // Import login command (uses mocked open)
+    const { loginCommand } = await import("../commands/login.js");
+
+    // Capture the URL that open() is called with so we can extract the port
+    let capturedUrl = "";
+    vi.mocked(open).mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      // Simulate the browser callback after a short delay
+      const parsedUrl = new URL(url);
+      const port = parsedUrl.searchParams.get("port");
+      setTimeout(() => {
+        http.get(`http://127.0.0.1:${port}/callback?key=fsk_testkey123&email=test@example.com`);
+      }, 50);
+      return undefined as any;
+    });
+
+    // Run the login action directly
+    await loginCommand.parseAsync(["login"], { from: "user" });
+
+    // Verify browser was opened with correct URL
+    expect(open).toHaveBeenCalledOnce();
+    expect(capturedUrl).toContain("https://test.fooshop.ai/cli-auth?port=");
+
+    // Verify config was saved
+    const config = readConfig();
+    expect(config).not.toBeNull();
+    expect(config!.apiKey).toBe("fsk_testkey123");
+    expect(config!.email).toBe("test@example.com");
+    expect(config!.baseUrl).toBe("https://test.fooshop.ai");
+  });
+
+  it("exits with error on denied callback", async () => {
+    const { loginCommand } = await import("../commands/login.js");
+
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => { throw new Error("exit"); });
+
+    vi.mocked(open).mockImplementation(async (url: string) => {
+      const parsedUrl = new URL(url);
+      const port = parsedUrl.searchParams.get("port");
+      setTimeout(() => {
+        http.get(`http://127.0.0.1:${port}/callback?error=denied`);
+      }, 50);
+      return undefined as any;
+    });
+
+    await expect(loginCommand.parseAsync(["login"], { from: "user" })).rejects.toThrow("exit");
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    // Config should NOT be saved
+    expect(readConfig()).toBeNull();
+    mockExit.mockRestore();
+  });
+});

--- a/cli/src/__tests__/server.test.ts
+++ b/cli/src/__tests__/server.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { startCallbackServer } from "../lib/server.js";
+import http from "http";
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function httpGet(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve({ status: res.statusCode!, body }));
+    }).on("error", reject);
+  });
+}
+
+describe("startCallbackServer", () => {
+  it("picks a random available port", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThan(65536);
+    close();
+  });
+
+  it("resolves with key and email on successful callback", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?key=fsk_test123&email=test@example.com`);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("Authentication complete");
+
+    const result = await promise;
+    expect(result).toEqual({ key: "fsk_test123", email: "test@example.com" });
+  });
+
+  it("returns 400 when key param is missing", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?email=test@example.com`);
+    expect(res.status).toBe(400);
+    close();
+  });
+
+  it("resolves with error on denied callback", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?error=denied`);
+    expect(res.status).toBe(200);
+
+    const result = await promise;
+    expect(result).toEqual({ error: "denied" });
+  });
+
+  it("only binds to 127.0.0.1", async () => {
+    const { port, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?key=fsk_x&email=a@b.com`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import { readConfig, writeConfig, getBaseUrl } from "../lib/config.js";
+import { startCallbackServer } from "../lib/server.js";
+import { openBrowser } from "../lib/open.js";
+
+const TIMEOUT_MS = 120_000;
+
+export const loginCommand = new Command("login")
+  .description("Authenticate with Fooshop via browser")
+  .allowExcessArguments(true)
+  .action(async () => {
+    const existing = readConfig();
+    if (existing?.apiKey) {
+      console.log(`Currently logged in as ${existing.email}`);
+      console.log("Running login again will replace the existing API key.\n");
+    }
+
+    const { port, promise, close } = await startCallbackServer();
+    const baseUrl = getBaseUrl();
+    const authUrl = `${baseUrl}/cli-auth?port=${port}`;
+
+    console.log("Opening browser for authentication...");
+    await openBrowser(authUrl);
+    console.log("Waiting for authentication...\n");
+
+    const timeout = setTimeout(() => {
+      close();
+      console.error("\nAuthentication timed out after 2 minutes.");
+      console.error("Please try again with: fooshop login");
+      process.exit(1);
+    }, TIMEOUT_MS);
+
+    const result = await promise;
+    clearTimeout(timeout);
+    close();
+
+    if ("error" in result) {
+      console.error(`\nAuthentication denied: ${result.error}`);
+      process.exit(1);
+    }
+
+    writeConfig({
+      apiKey: result.key,
+      baseUrl,
+      email: result.email,
+    });
+
+    console.log(`✓ Logged in as ${result.email}`);
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { loginCommand } from "./commands/login.js";
 
 const program = new Command();
 
@@ -9,7 +10,6 @@ program
   .description("Fooshop CLI — commerce from your terminal")
   .version("0.1.0");
 
-// Commands will be registered here
-// program.addCommand(loginCommand);
+program.addCommand(loginCommand);
 
 program.parse();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+
+const program = new Command();
+
+program
+  .name("fooshop")
+  .description("Fooshop CLI — commerce from your terminal")
+  .version("0.1.0");
+
+// Commands will be registered here
+// program.addCommand(loginCommand);
+
+program.parse();

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,0 +1,44 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+export interface FooshopConfig {
+  apiKey: string;
+  baseUrl: string;
+  email: string;
+}
+
+const DEFAULT_BASE_URL = "https://fooshop.ai";
+
+function getConfigDir(): string {
+  return process.env.FOOSHOP_CONFIG_DIR || path.join(os.homedir(), ".fooshop");
+}
+
+function getConfigPath(): string {
+  return path.join(getConfigDir(), "config.json");
+}
+
+export function readConfig(): FooshopConfig | null {
+  try {
+    const raw = fs.readFileSync(getConfigPath(), "utf-8");
+    return JSON.parse(raw) as FooshopConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function writeConfig(config: FooshopConfig): void {
+  const dir = getConfigDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function getApiKey(): string | null {
+  return process.env.FOOSHOP_API_KEY || readConfig()?.apiKey || null;
+}
+
+export function getBaseUrl(): string {
+  return process.env.FOOSHOP_BASE_URL || readConfig()?.baseUrl || DEFAULT_BASE_URL;
+}

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -1,0 +1,10 @@
+import open from "open";
+
+export async function openBrowser(url: string): Promise<void> {
+  try {
+    await open(url);
+  } catch {
+    // If open fails (e.g., no display), print the URL for manual copy
+    console.log(`\nOpen this URL in your browser:\n  ${url}\n`);
+  }
+}

--- a/cli/src/lib/server.ts
+++ b/cli/src/lib/server.ts
@@ -1,0 +1,77 @@
+import * as http from "http";
+import * as net from "net";
+import { URL } from "url";
+
+export type CallbackResult =
+  | { key: string; email: string }
+  | { error: string };
+
+interface ServerHandle {
+  port: number;
+  promise: Promise<CallbackResult>;
+  close: () => void;
+}
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(addr.port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+export async function startCallbackServer(): Promise<ServerHandle> {
+  const port = await findFreePort();
+
+  let resolvePromise: (result: CallbackResult) => void;
+  const promise = new Promise<CallbackResult>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url!, `http://127.0.0.1:${port}`);
+
+    if (url.pathname !== "/callback") {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+
+    const error = url.searchParams.get("error");
+    if (error) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html><body><h1>Authentication denied.</h1><p>You can close this tab.</p></body></html>");
+      resolvePromise({ error });
+      return;
+    }
+
+    const key = url.searchParams.get("key");
+    const email = url.searchParams.get("email");
+
+    if (!key || !email) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Missing key or email parameter");
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(
+      "<html><body><h1>&#10003; Authentication complete.</h1><p>You can close this tab and return to your terminal.</p></body></html>"
+    );
+
+    resolvePromise({ key, email });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, "127.0.0.1", () => resolve());
+  });
+
+  const close = () => {
+    server.close();
+  };
+
+  return { port, promise, close };
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/docs/superpowers/plans/2026-03-19-cli-setup-auth-flow.md
+++ b/docs/superpowers/plans/2026-03-19-cli-setup-auth-flow.md
@@ -1,0 +1,988 @@
+# CLI Package Setup + Auth Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `fooshop` CLI npm package with `fooshop login` browser-based auth flow, plus the web endpoints (`/cli-auth` page, `/api/auth/cli-callback`) that generate and deliver API keys.
+
+**Architecture:** CLI package in `cli/` (Commander.js + TypeScript), compiled to `dist/`. Web side adds two routes to the existing Next.js app. Auth flow: CLI opens browser → user authenticates via Google OAuth → approves CLI access → server generates API key → redirects to localhost callback → CLI saves key to `~/.fooshop/config.json`.
+
+**Tech Stack:** Commander.js, Node.js `net`/`http` modules, `open` package, Next.js App Router (server components + API route), Drizzle ORM, Auth.js
+
+**Spec:** `docs/superpowers/specs/2026-03-19-cli-setup-auth-flow-design.md`
+
+---
+
+## File Map
+
+### CLI Package (new files in `cli/`)
+
+| File | Responsibility |
+|------|---------------|
+| `cli/package.json` | Package manifest: name `fooshop`, bin entry, dependencies |
+| `cli/tsconfig.json` | TypeScript config (ES2022, Node16 module) |
+| `cli/src/index.ts` | Commander entry point, registers `login` command |
+| `cli/src/commands/login.ts` | Login command: orchestrates server → browser → callback → save |
+| `cli/src/lib/config.ts` | Read/write `~/.fooshop/config.json`, env var overrides |
+| `cli/src/lib/server.ts` | Localhost HTTP callback server (find port, start, handle callback) |
+| `cli/src/lib/open.ts` | Open URL in default browser (wrapper around `open` package) |
+
+### CLI Tests (new files in `cli/`)
+
+| File | Responsibility |
+|------|---------------|
+| `cli/src/__tests__/config.test.ts` | Config read/write/env override tests |
+| `cli/src/__tests__/server.test.ts` | Callback server tests (port finding, request handling) |
+| `cli/src/__tests__/login.test.ts` | Login command integration test (mocked browser + server) |
+
+### Web Endpoints (new files in `src/app/`)
+
+| File | Responsibility |
+|------|---------------|
+| `src/app/(platform)/cli-auth/page.tsx` | Approval page: session check, nonce cookie, form UI |
+| `src/app/api/auth/cli-callback/route.ts` | POST handler: validate session + nonce, find/create creator, generate key, redirect to localhost |
+
+---
+
+## Task 1: CLI Package Scaffold
+
+**Files:**
+- Create: `cli/package.json`
+- Create: `cli/tsconfig.json`
+- Create: `cli/src/index.ts`
+
+- [ ] **Step 1: Create `cli/package.json`**
+
+```json
+{
+  "name": "fooshop",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Fooshop CLI — commerce from your terminal",
+  "main": "dist/index.js",
+  "bin": {
+    "fooshop": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": ["dist"],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "commander": "^13.0.0",
+    "open": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5",
+    "vitest": "^2.1.9"
+  }
+}
+```
+
+- [ ] **Step 2: Create `cli/tsconfig.json`**
+
+Match the MCP server pattern (`mcp-server/tsconfig.json`):
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3: Create `cli/src/index.ts`**
+
+Entry point with shebang, registers the `login` command (stubbed for now):
+
+```typescript
+#!/usr/bin/env node
+
+import { Command } from "commander";
+
+const program = new Command();
+
+program
+  .name("fooshop")
+  .description("Fooshop CLI — commerce from your terminal")
+  .version("0.1.0");
+
+// Commands will be registered here
+// program.addCommand(loginCommand);
+
+program.parse();
+```
+
+- [ ] **Step 4: Create `cli/.gitignore`**
+
+```
+node_modules/
+dist/
+```
+
+- [ ] **Step 5: Verify `cli/` is not captured by pnpm workspace**
+
+Run: `cat pnpm-workspace.yaml 2>/dev/null || echo "no workspace file"`
+
+If the workspace file has a glob that would match `cli/`, add `"!cli"` to the `packages` array to exclude it. The CLI is a standalone package, not part of the monorepo workspace.
+
+- [ ] **Step 6: Install dependencies and verify build**
+
+Run: `cd cli && pnpm install && pnpm build`
+Expected: Clean compile, `dist/index.js` created with shebang
+
+- [ ] **Step 7: Verify CLI runs**
+
+Run: `node cli/dist/index.js --help`
+Expected: Shows "Fooshop CLI — commerce from your terminal" and version
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/
+git commit -m "feat: scaffold fooshop CLI package with Commander.js (#81)"
+```
+
+---
+
+## Task 2: Config Module
+
+**Files:**
+- Create: `cli/src/lib/config.ts`
+- Create: `cli/src/__tests__/config.test.ts`
+
+- [ ] **Step 1: Write failing tests for config module**
+
+Create `cli/src/__tests__/config.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readConfig, writeConfig, getApiKey, getBaseUrl } from "../lib/config.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// Use a temp dir to avoid touching real ~/.fooshop
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("readConfig", () => {
+  it("returns null when config file does not exist", () => {
+    expect(readConfig()).toBeNull();
+  });
+
+  it("reads existing config file", () => {
+    const config = { apiKey: "fsk_test123", baseUrl: "https://fooshop.ai", email: "test@example.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(readConfig()).toEqual(config);
+  });
+
+  it("returns null for malformed JSON", () => {
+    fs.writeFileSync(path.join(tmpDir, "config.json"), "not json");
+    expect(readConfig()).toBeNull();
+  });
+});
+
+describe("writeConfig", () => {
+  it("creates directory and writes config", () => {
+    const nestedDir = path.join(tmpDir, "nested");
+    vi.stubEnv("FOOSHOP_CONFIG_DIR", nestedDir);
+    writeConfig({ apiKey: "fsk_abc", baseUrl: "https://fooshop.ai", email: "a@b.com" });
+    const content = JSON.parse(fs.readFileSync(path.join(nestedDir, "config.json"), "utf-8"));
+    expect(content.apiKey).toBe("fsk_abc");
+  });
+});
+
+describe("getApiKey", () => {
+  it("returns env var over config file", () => {
+    vi.stubEnv("FOOSHOP_API_KEY", "fsk_from_env");
+    const config = { apiKey: "fsk_from_file", baseUrl: "https://fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getApiKey()).toBe("fsk_from_env");
+  });
+
+  it("returns config file value when env not set", () => {
+    const config = { apiKey: "fsk_from_file", baseUrl: "https://fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getApiKey()).toBe("fsk_from_file");
+  });
+
+  it("returns null when nothing is set", () => {
+    expect(getApiKey()).toBeNull();
+  });
+});
+
+describe("getBaseUrl", () => {
+  it("returns env var over config file", () => {
+    vi.stubEnv("FOOSHOP_BASE_URL", "https://staging.fooshop.ai");
+    expect(getBaseUrl()).toBe("https://staging.fooshop.ai");
+  });
+
+  it("returns config value when env not set", () => {
+    const config = { apiKey: "fsk_x", baseUrl: "https://custom.fooshop.ai", email: "t@t.com" };
+    fs.writeFileSync(path.join(tmpDir, "config.json"), JSON.stringify(config));
+    expect(getBaseUrl()).toBe("https://custom.fooshop.ai");
+  });
+
+  it("returns default when nothing is set", () => {
+    expect(getBaseUrl()).toBe("https://fooshop.ai");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cli && pnpm test`
+Expected: All tests FAIL — module `../lib/config.js` not found
+
+- [ ] **Step 3: Implement config module**
+
+Create `cli/src/lib/config.ts`:
+
+```typescript
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+export interface FooshopConfig {
+  apiKey: string;
+  baseUrl: string;
+  email: string;
+}
+
+const DEFAULT_BASE_URL = "https://fooshop.ai";
+
+function getConfigDir(): string {
+  return process.env.FOOSHOP_CONFIG_DIR || path.join(os.homedir(), ".fooshop");
+}
+
+function getConfigPath(): string {
+  return path.join(getConfigDir(), "config.json");
+}
+
+export function readConfig(): FooshopConfig | null {
+  try {
+    const raw = fs.readFileSync(getConfigPath(), "utf-8");
+    return JSON.parse(raw) as FooshopConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function writeConfig(config: FooshopConfig): void {
+  const dir = getConfigDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function getApiKey(): string | null {
+  return process.env.FOOSHOP_API_KEY || readConfig()?.apiKey || null;
+}
+
+export function getBaseUrl(): string {
+  return process.env.FOOSHOP_BASE_URL || readConfig()?.baseUrl || DEFAULT_BASE_URL;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cli && pnpm test`
+Expected: All config tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/lib/config.ts cli/src/__tests__/config.test.ts
+git commit -m "feat: add CLI config module with env var overrides (#81)"
+```
+
+---
+
+## Task 3: Localhost Callback Server
+
+**Files:**
+- Create: `cli/src/lib/server.ts`
+- Create: `cli/src/__tests__/server.test.ts`
+
+- [ ] **Step 1: Write failing tests for callback server**
+
+Create `cli/src/__tests__/server.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach } from "vitest";
+import { startCallbackServer } from "../lib/server.js";
+import http from "http";
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+function httpGet(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve({ status: res.statusCode!, body }));
+    }).on("error", reject);
+  });
+}
+
+describe("startCallbackServer", () => {
+  it("picks a random available port", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThan(65536);
+    close();
+  });
+
+  it("resolves with key and email on successful callback", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?key=fsk_test123&email=test@example.com`);
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("Authentication complete");
+
+    const result = await promise;
+    expect(result).toEqual({ key: "fsk_test123", email: "test@example.com" });
+  });
+
+  it("returns 400 when key param is missing", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?email=test@example.com`);
+    expect(res.status).toBe(400);
+    close();
+  });
+
+  it("resolves with error on denied callback", async () => {
+    const { port, promise, close } = await startCallbackServer();
+    cleanup = close;
+
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?error=denied`);
+    expect(res.status).toBe(200);
+
+    const result = await promise;
+    expect(result).toEqual({ error: "denied" });
+  });
+
+  it("only binds to 127.0.0.1", async () => {
+    const { port, close } = await startCallbackServer();
+    cleanup = close;
+
+    // Server should be listening on 127.0.0.1, confirmed by successful connection
+    const res = await httpGet(`http://127.0.0.1:${port}/callback?key=fsk_x&email=a@b.com`);
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cli && pnpm test -- src/__tests__/server.test.ts`
+Expected: FAIL — module `../lib/server.js` not found
+
+- [ ] **Step 3: Implement callback server**
+
+Create `cli/src/lib/server.ts`:
+
+```typescript
+import * as http from "http";
+import * as net from "net";
+import { URL } from "url";
+
+export type CallbackResult =
+  | { key: string; email: string }
+  | { error: string };
+
+interface ServerHandle {
+  port: number;
+  promise: Promise<CallbackResult>;
+  close: () => void;
+}
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(addr.port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+export async function startCallbackServer(): Promise<ServerHandle> {
+  const port = await findFreePort();
+
+  let resolvePromise: (result: CallbackResult) => void;
+  const promise = new Promise<CallbackResult>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url!, `http://127.0.0.1:${port}`);
+
+    if (url.pathname !== "/callback") {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+
+    const error = url.searchParams.get("error");
+    if (error) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html><body><h1>Authentication denied.</h1><p>You can close this tab.</p></body></html>");
+      resolvePromise({ error });
+      return;
+    }
+
+    const key = url.searchParams.get("key");
+    const email = url.searchParams.get("email");
+
+    if (!key || !email) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Missing key or email parameter");
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(
+      "<html><body><h1>&#10003; Authentication complete.</h1><p>You can close this tab and return to your terminal.</p></body></html>"
+    );
+
+    resolvePromise({ key, email });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, "127.0.0.1", () => resolve());
+  });
+
+  const close = () => {
+    server.close();
+  };
+
+  return { port, promise, close };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd cli && pnpm test -- src/__tests__/server.test.ts`
+Expected: All server tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/lib/server.ts cli/src/__tests__/server.test.ts
+git commit -m "feat: add localhost callback server for CLI auth (#81)"
+```
+
+---
+
+## Task 4: Browser Open Utility
+
+**Files:**
+- Create: `cli/src/lib/open.ts`
+
+- [ ] **Step 1: Create browser open wrapper**
+
+Create `cli/src/lib/open.ts`:
+
+```typescript
+import open from "open";
+
+export async function openBrowser(url: string): Promise<void> {
+  try {
+    await open(url);
+  } catch {
+    // If open fails (e.g., no display), print the URL for manual copy
+    console.log(`\nOpen this URL in your browser:\n  ${url}\n`);
+  }
+}
+```
+
+No tests needed — thin wrapper around `open` package with a fallback.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cli/src/lib/open.ts
+git commit -m "feat: add browser open utility for CLI (#81)"
+```
+
+---
+
+## Task 5: Login Command
+
+**Files:**
+- Create: `cli/src/commands/login.ts`
+- Modify: `cli/src/index.ts` (register login command)
+- Create: `cli/src/__tests__/login.test.ts`
+
+- [ ] **Step 1: Write failing test for login command**
+
+Create `cli/src/__tests__/login.test.ts`. This tests the login command action by mocking the browser open and simulating the callback:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import http from "http";
+
+// Mock the open module before any imports that use it
+vi.mock("open", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { readConfig } from "../lib/config.js";
+import open from "open";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("login command", () => {
+  it("opens browser, receives callback, saves config", async () => {
+    // Import login command (uses mocked open)
+    const { loginCommand } = await import("../commands/login.js");
+
+    // Capture the URL that open() is called with so we can extract the port
+    let capturedUrl = "";
+    vi.mocked(open).mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      // Simulate the browser callback after a short delay
+      const parsedUrl = new URL(url);
+      const port = parsedUrl.searchParams.get("port");
+      setTimeout(() => {
+        http.get(`http://127.0.0.1:${port}/callback?key=fsk_testkey123&email=test@example.com`);
+      }, 50);
+      return undefined as any;
+    });
+
+    // Run the login action directly
+    await loginCommand.parseAsync(["login"], { from: "user" });
+
+    // Verify browser was opened with correct URL
+    expect(open).toHaveBeenCalledOnce();
+    expect(capturedUrl).toContain("https://test.fooshop.ai/cli-auth?port=");
+
+    // Verify config was saved
+    const config = readConfig();
+    expect(config).not.toBeNull();
+    expect(config!.apiKey).toBe("fsk_testkey123");
+    expect(config!.email).toBe("test@example.com");
+    expect(config!.baseUrl).toBe("https://test.fooshop.ai");
+  });
+
+  it("exits with error on denied callback", async () => {
+    const { loginCommand } = await import("../commands/login.js");
+
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => { throw new Error("exit"); });
+
+    vi.mocked(open).mockImplementation(async (url: string) => {
+      const parsedUrl = new URL(url);
+      const port = parsedUrl.searchParams.get("port");
+      setTimeout(() => {
+        http.get(`http://127.0.0.1:${port}/callback?error=denied`);
+      }, 50);
+      return undefined as any;
+    });
+
+    await expect(loginCommand.parseAsync(["login"], { from: "user" })).rejects.toThrow("exit");
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    // Config should NOT be saved
+    expect(readConfig()).toBeNull();
+    mockExit.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** (login command not yet implemented)
+
+Run: `cd cli && pnpm test -- src/__tests__/login.test.ts`
+Expected: FAIL — module `../commands/login.js` not found
+
+- [ ] **Step 3: Implement login command**
+
+Create `cli/src/commands/login.ts`:
+
+```typescript
+import { Command } from "commander";
+import { readConfig, writeConfig, getBaseUrl } from "../lib/config.js";
+import { startCallbackServer } from "../lib/server.js";
+import { openBrowser } from "../lib/open.js";
+
+const TIMEOUT_MS = 120_000;
+
+export const loginCommand = new Command("login")
+  .description("Authenticate with Fooshop via browser")
+  .action(async () => {
+    const existing = readConfig();
+    if (existing?.apiKey) {
+      console.log(`Currently logged in as ${existing.email}`);
+      console.log("Running login again will replace the existing API key.\n");
+    }
+
+    const { port, promise, close } = await startCallbackServer();
+    const baseUrl = getBaseUrl();
+    const authUrl = `${baseUrl}/cli-auth?port=${port}`;
+
+    console.log("Opening browser for authentication...");
+    await openBrowser(authUrl);
+    console.log("Waiting for authentication...\n");
+
+    const timeout = setTimeout(() => {
+      close();
+      console.error("\nAuthentication timed out after 2 minutes.");
+      console.error("Please try again with: fooshop login");
+      process.exit(1);
+    }, TIMEOUT_MS);
+
+    const result = await promise;
+    clearTimeout(timeout);
+    close();
+
+    if ("error" in result) {
+      console.error(`\nAuthentication denied: ${result.error}`);
+      process.exit(1);
+    }
+
+    writeConfig({
+      apiKey: result.key,
+      baseUrl,
+      email: result.email,
+    });
+
+    console.log(`✓ Logged in as ${result.email}`);
+  });
+```
+
+- [ ] **Step 4: Register login command in `cli/src/index.ts`**
+
+Update `cli/src/index.ts`:
+
+```typescript
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { loginCommand } from "./commands/login.js";
+
+const program = new Command();
+
+program
+  .name("fooshop")
+  .description("Fooshop CLI — commerce from your terminal")
+  .version("0.1.0");
+
+program.addCommand(loginCommand);
+
+program.parse();
+```
+
+- [ ] **Step 5: Build and verify `fooshop login --help`**
+
+Run: `cd cli && pnpm build && node dist/index.js login --help`
+Expected: Shows "Authenticate with Fooshop via browser"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/login.ts cli/src/index.ts cli/src/__tests__/login.test.ts
+git commit -m "feat: implement fooshop login command (#81)"
+```
+
+---
+
+## Task 6: Web — `/cli-auth` Approval Page
+
+**Files:**
+- Create: `src/app/(platform)/cli-auth/page.tsx`
+
+This task is in the **Next.js app** (not the CLI package). Working directory: project root.
+
+- [ ] **Step 1: Create the cli-auth page**
+
+Create `src/app/(platform)/cli-auth/page.tsx`:
+
+```tsx
+export const dynamic = "force-dynamic";
+
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+
+interface Props {
+  searchParams: Promise<{ port?: string }>;
+}
+
+export default async function CliAuthPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const port = params.port;
+
+  // Validate port parameter
+  const portNum = port ? parseInt(port, 10) : NaN;
+  if (!port || isNaN(portNum) || portNum < 1024 || portNum > 65535) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="max-w-md mx-auto text-center p-8">
+          <h1 className="text-2xl font-bold text-red-600 mb-4">Invalid Request</h1>
+          <p className="text-gray-600">Missing or invalid port parameter. Please run <code className="bg-gray-100 px-2 py-1 rounded">fooshop login</code> again.</p>
+        </div>
+      </main>
+    );
+  }
+
+  // Check session
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(`/cli-auth?port=${port}`)}`);
+  }
+
+  // Generate CSRF nonce
+  const nonce = crypto.randomUUID();
+  const cookieStore = await cookies();
+  cookieStore.set("cli-auth-nonce", nonce, {
+    httpOnly: true,
+    sameSite: "strict",
+    maxAge: 60,
+    path: "/api/auth/cli-callback",
+  });
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow-lg p-8 text-center">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold tracking-tight" style={{ fontFamily: "var(--font-display)" }}>
+            fooshop
+          </h1>
+        </div>
+
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          CLI wants to access your account
+        </h2>
+
+        <p className="text-gray-600 mb-6">
+          {session.user.name && <span>{session.user.name}<br /></span>}
+          Signed in as <strong>{session.user.email}</strong>
+        </p>
+
+        <p className="text-sm text-gray-500 mb-8">
+          This will create an API key with full access to your store, products, orders, and analytics.
+        </p>
+
+        <form method="POST" action="/api/auth/cli-callback">
+          <input type="hidden" name="port" value={port} />
+          <input type="hidden" name="nonce" value={nonce} />
+
+          <button
+            type="submit"
+            className="w-full bg-black text-white py-3 px-6 rounded-lg font-medium hover:bg-gray-800 transition-colors mb-3"
+          >
+            Approve
+          </button>
+        </form>
+
+        <a
+          href={`http://127.0.0.1:${port}/callback?error=denied`}
+          className="block w-full text-center py-3 px-6 rounded-lg font-medium text-gray-600 hover:bg-gray-100 transition-colors"
+        >
+          Deny
+        </a>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `pnpm build`
+Expected: Build succeeds with `/cli-auth` in the route list
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(platform\)/cli-auth/page.tsx
+git commit -m "feat: add /cli-auth approval page for CLI login (#81)"
+```
+
+---
+
+## Task 7: Web — `/api/auth/cli-callback` Endpoint
+
+**Files:**
+- Create: `src/app/api/auth/cli-callback/route.ts`
+
+- [ ] **Step 1: Implement the callback endpoint**
+
+Create `src/app/api/auth/cli-callback/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { creators, apiKeys } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { generateApiKey, CREATOR_SCOPES } from "@/lib/api-key";
+import { cookies } from "next/headers";
+
+function generateSlug(email: string): string {
+  const prefix = email.split("@")[0]
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  const suffix = crypto.randomUUID().slice(0, 4);
+  return `${prefix}-${suffix}`;
+}
+
+export async function POST(req: NextRequest) {
+  // 1. Verify session
+  const session = await auth();
+  if (!session?.user?.id || !session.user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 2. Parse form data
+  const formData = await req.formData();
+  const nonce = formData.get("nonce") as string | null;
+  const portStr = formData.get("port") as string | null;
+
+  // 3. Validate CSRF nonce
+  const cookieStore = await cookies();
+  const cookieNonce = cookieStore.get("cli-auth-nonce")?.value;
+  cookieStore.delete("cli-auth-nonce");
+
+  if (!nonce || !cookieNonce || nonce !== cookieNonce) {
+    return NextResponse.json({ error: "Invalid or expired nonce" }, { status: 403 });
+  }
+
+  // 4. Validate port
+  const port = portStr ? parseInt(portStr, 10) : NaN;
+  if (isNaN(port) || port < 1024 || port > 65535) {
+    return NextResponse.json({ error: "Invalid port" }, { status: 400 });
+  }
+
+  // 5. Find or create creator
+  let creator = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.userId, session.user.id))
+    .then((rows) => rows[0]);
+
+  if (!creator) {
+    const [newCreator] = await db
+      .insert(creators)
+      .values({
+        userId: session.user.id,
+        email: session.user.email,
+        name: session.user.name || session.user.email.split("@")[0],
+        slug: generateSlug(session.user.email),
+      })
+      .returning();
+    creator = newCreator;
+  }
+
+  // 6. Revoke existing CLI key (prevent accumulation)
+  await db
+    .delete(apiKeys)
+    .where(
+      and(eq(apiKeys.creatorId, creator.id), eq(apiKeys.name, "Fooshop CLI"))
+    );
+
+  // 7. Generate new API key
+  const { key, prefix, hash } = generateApiKey();
+  await db.insert(apiKeys).values({
+    creatorId: creator.id,
+    keyHash: hash,
+    keyPrefix: prefix,
+    name: "Fooshop CLI",
+    scopes: [...CREATOR_SCOPES],
+  });
+
+  // 8. Redirect to localhost callback
+  const redirectUrl = `http://127.0.0.1:${port}/callback?key=${encodeURIComponent(key)}&email=${encodeURIComponent(session.user.email)}`;
+  return NextResponse.redirect(redirectUrl, 302);
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `pnpm build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/auth/cli-callback/route.ts
+git commit -m "feat: add /api/auth/cli-callback endpoint for CLI key generation (#81)"
+```
+
+---
+
+## Task 8: Build Verification & Manual Test
+
+- [ ] **Step 1: Run all CLI tests**
+
+Run: `cd cli && pnpm test`
+Expected: All tests pass
+
+- [ ] **Step 2: Run Next.js build**
+
+Run: `pnpm build`
+Expected: Clean build with `/cli-auth` and `/api/auth/cli-callback` in route list
+
+- [ ] **Step 3: Run existing project tests**
+
+Run: `pnpm test`
+Expected: All existing tests still pass (no regressions)
+
+- [ ] **Step 4: Commit any fixes if needed**
+
+Only if previous steps revealed issues.
+
+- [ ] **Step 5: Final commit with all files verified**
+
+Verify git status is clean. All changes committed.

--- a/docs/superpowers/specs/2026-03-19-cli-setup-auth-flow-design.md
+++ b/docs/superpowers/specs/2026-03-19-cli-setup-auth-flow-design.md
@@ -1,0 +1,160 @@
+# CLI Package Setup + Auth Flow (fooshop login)
+
+**Issue:** #81
+**Date:** 2026-03-19
+**Status:** Design
+
+## Overview
+
+New npm package `fooshop` in `cli/` directory. First command: `fooshop login` — browser-based OAuth flow that generates an API key and saves it locally.
+
+## Architecture
+
+Two parts: CLI package (standalone npm) and web endpoints (existing Next.js app).
+
+### Auth Flow
+
+```
+CLI (fooshop login)
+  → finds free port, starts localhost HTTP server on :<port>
+  → opens browser to <baseUrl>/cli-auth?port=<port>
+
+Browser (/cli-auth)
+  → if not logged in: redirect to Google OAuth, then back to /cli-auth?port=<port>
+  → if logged in: show approval page ("Fooshop CLI wants to access your account")
+  → user clicks "Approve"
+  → POST /api/auth/cli-callback with port in body
+
+Server (/api/auth/cli-callback)
+  → verify session
+  → find or create creator record
+  → generate API key (all CREATOR_SCOPES)
+  → redirect to http://localhost:<port>/callback?key=fsk_xxx&email=user@example.com
+
+CLI receives callback
+  → saves key + email + baseUrl to ~/.fooshop/config.json
+  → prints "✓ Logged in as user@example.com"
+  → shuts down server, exits
+```
+
+## CLI Package
+
+### Structure
+
+```
+cli/
+  package.json          # name: "fooshop", bin: { fooshop: "./dist/index.js" }
+  tsconfig.json
+  src/
+    index.ts            # Commander.js entry point
+    commands/
+      login.ts          # fooshop login command
+    lib/
+      config.ts         # read/write ~/.fooshop/config.json
+      server.ts         # localhost callback HTTP server
+      open.ts           # open browser cross-platform
+```
+
+### Dependencies
+
+- `commander` — CLI framework
+- `open` — cross-platform browser open
+
+### Config File
+
+`~/.fooshop/config.json`:
+
+```json
+{
+  "apiKey": "fsk_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "baseUrl": "https://fooshop.ai",
+  "email": "emanuele@exelab.com"
+}
+```
+
+Environment variable overrides:
+- `FOOSHOP_BASE_URL` — overrides `baseUrl` (defaults to `https://fooshop.ai`)
+- `FOOSHOP_API_KEY` — overrides `apiKey` from config file
+
+### Login Command
+
+1. Check if already logged in (config exists with valid key) — if so, print current email and ask to re-login
+2. Find a free port using Node.js `net.createServer().listen(0)`
+3. Start HTTP server on `localhost:<port>`
+4. Open browser to `<baseUrl>/cli-auth?port=<port>`
+5. Print "Waiting for authentication..." with spinner
+6. Server handles GET `/callback?key=<key>&email=<email>`:
+   - Save to config file
+   - Respond with HTML: "✓ Authentication complete. You can close this tab."
+   - Print "✓ Logged in as <email>" to terminal
+   - Shut down server, exit with code 0
+7. Timeout after 120 seconds — print error, exit with code 1
+
+### Build
+
+- TypeScript compiled with `tsc` to `dist/`
+- Standalone package (not in pnpm workspace) — simpler for npm publish
+- `#!/usr/bin/env node` shebang in entry point
+
+## Web Endpoints
+
+### `/cli-auth` Page
+
+Location: `src/app/cli-auth/page.tsx`
+
+Server component:
+1. Read `port` from search params, validate it's a number
+2. Check session via `auth()`
+3. If not logged in → redirect to `/api/auth/signin?callbackUrl=/cli-auth?port=<port>`
+4. If logged in → render approval page
+
+Approval page UI:
+- Fooshop logo
+- "Fooshop CLI wants to access your account"
+- Shows user email and name
+- "Approve" button → POST to `/api/auth/cli-callback`
+- "Deny" button → redirect to localhost with `?error=denied`
+
+### `/api/auth/cli-callback` Endpoint
+
+Location: `src/app/api/auth/cli-callback/route.ts`
+
+POST handler:
+1. Verify session via `auth()` — 401 if not authenticated
+2. Read `port` from request body (JSON), validate as integer in range 1024-65535
+3. Look up creator by `session.user.id`:
+   - If exists: use existing creator
+   - If not: create new creator record with `email`, `name` from session, no slug
+4. Check for existing CLI API key for this creator (name: "Fooshop CLI"):
+   - If exists: revoke old key (delete from DB), generate new one
+   - This prevents key accumulation from repeated `fooshop login`
+5. Generate API key via `generateApiKey()` from `src/lib/api-key.ts`
+6. Insert into `apiKeys` table:
+   - `creatorId`: creator's ID
+   - `name`: "Fooshop CLI"
+   - `scopes`: all `CREATOR_SCOPES`
+   - `expiresAt`: null (no expiry)
+7. Redirect (302) to `http://localhost:<port>/callback?key=<plaintext_key>&email=<email>`
+
+## Security
+
+- **Port validation:** Integer, range 1024-65535
+- **Localhost only:** CLI server binds to `127.0.0.1`, not `0.0.0.0`
+- **Session-gated:** API key generation requires active session cookie
+- **Key rotation:** Repeated logins revoke previous CLI key
+- **Key in URL:** Appears only in localhost redirect — same pattern as GitHub CLI, Stripe CLI, Vercel CLI. Key never stored in browser, only in terminal config file.
+- **No PKCE needed:** The API key is generated server-side and passed to localhost. No client secret exchange. If needed in future, can add PKCE.
+
+## Testing
+
+- **CLI unit tests:** config read/write, port finding, callback parsing
+- **Integration test:** mock the full login flow with a fake server
+- **Web endpoint tests:** `/api/auth/cli-callback` with valid/invalid session, creator auto-creation
+- **Manual test:** `npx fooshop login` against staging
+
+## Out of Scope
+
+- Other CLI commands (`fooshop init`, `fooshop products`, etc.) — separate issues
+- API key scoping per command — all CREATOR_SCOPES for now
+- PKCE or code exchange — unnecessary for localhost redirect pattern
+- Windows support — macOS and Linux only per acceptance criteria

--- a/docs/superpowers/specs/2026-03-19-cli-setup-auth-flow-design.md
+++ b/docs/superpowers/specs/2026-03-19-cli-setup-auth-flow-design.md
@@ -66,7 +66,7 @@ cli/
 
 ```json
 {
-  "apiKey": "fsk_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "apiKey": "fsk_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
   "baseUrl": "https://fooshop.ai",
   "email": "emanuele@exelab.com"
 }
@@ -112,35 +112,41 @@ Approval page UI:
 - Fooshop logo
 - "Fooshop CLI wants to access your account"
 - Shows user email and name
-- "Approve" button → POST to `/api/auth/cli-callback`
+- **Form submission** (not fetch/AJAX) — `<form method="POST" action="/api/auth/cli-callback">` with hidden `port` and `nonce` fields
+- "Approve" button submits the form — browser follows the 302 redirect natively
 - "Deny" button → redirect to localhost with `?error=denied`
+
+**CSRF protection:** Server component generates a one-time `nonce` (random UUID), stores it in a short-lived cookie (60s, httpOnly, sameSite=strict). The `/api/auth/cli-callback` endpoint validates that the nonce in the form body matches the cookie, then deletes the cookie.
 
 ### `/api/auth/cli-callback` Endpoint
 
 Location: `src/app/api/auth/cli-callback/route.ts`
 
-POST handler:
+POST handler (receives form data, not JSON):
 1. Verify session via `auth()` — 401 if not authenticated
-2. Read `port` from request body (JSON), validate as integer in range 1024-65535
-3. Look up creator by `session.user.id`:
+2. Validate CSRF nonce: compare form body `nonce` with `cli-auth-nonce` cookie — 403 if mismatch, then delete cookie
+3. Read `port` from form body, validate as integer in range 1024-65535
+4. Look up creator by `session.user.id`:
    - If exists: use existing creator
-   - If not: create new creator record with `email`, `name` from session, no slug
-4. Check for existing CLI API key for this creator (name: "Fooshop CLI"):
+   - If not: create new creator record with `email`, `name` from session, slug derived from email prefix + random suffix (e.g., `emanuele-a3f7`) to satisfy NOT NULL unique constraint
+5. Check for existing CLI API key for this creator (name: "Fooshop CLI"):
    - If exists: revoke old key (delete from DB), generate new one
    - This prevents key accumulation from repeated `fooshop login`
-5. Generate API key via `generateApiKey()` from `src/lib/api-key.ts`
-6. Insert into `apiKeys` table:
+6. Generate API key via `generateApiKey()` from `src/lib/api-key.ts`
+7. Insert into `apiKeys` table:
    - `creatorId`: creator's ID
    - `name`: "Fooshop CLI"
    - `scopes`: all `CREATOR_SCOPES`
    - `expiresAt`: null (no expiry)
-7. Redirect (302) to `http://localhost:<port>/callback?key=<plaintext_key>&email=<email>`
+8. Redirect (302) to `http://localhost:<port>/callback?key=<plaintext_key>&email=<email>`
 
 ## Security
 
 - **Port validation:** Integer, range 1024-65535
 - **Localhost only:** CLI server binds to `127.0.0.1`, not `0.0.0.0`
 - **Session-gated:** API key generation requires active session cookie
+- **CSRF nonce:** One-time nonce in form + httpOnly cookie prevents cross-site request forgery
+- **Form submission:** Uses native form POST (not fetch) so browser follows 302 redirect to localhost
 - **Key rotation:** Repeated logins revoke previous CLI key
 - **Key in URL:** Appears only in localhost redirect — same pattern as GitHub CLI, Stripe CLI, Vercel CLI. Key never stored in browser, only in terminal config file.
 - **No PKCE needed:** The API key is generated server-side and passed to localhost. No client secret exchange. If needed in future, can add PKCE.
@@ -155,6 +161,8 @@ POST handler:
 ## Out of Scope
 
 - Other CLI commands (`fooshop init`, `fooshop products`, etc.) — separate issues
+- `fooshop logout` and `fooshop whoami` — will be added as follow-up commands
 - API key scoping per command — all CREATOR_SCOPES for now
 - PKCE or code exchange — unnecessary for localhost redirect pattern
 - Windows support — macOS and Linux only per acceptance criteria
+- Config file is shared with admin CLI (`~/.fooshop/config.json`) — both use same `apiKey` field. Admin CLI will need a separate key field if admin-scoped keys are needed in the future

--- a/src/app/(platform)/cli-auth/page.tsx
+++ b/src/app/(platform)/cli-auth/page.tsx
@@ -1,0 +1,87 @@
+export const dynamic = "force-dynamic";
+
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+
+interface Props {
+  searchParams: Promise<{ port?: string }>;
+}
+
+export default async function CliAuthPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const port = params.port;
+
+  // Validate port parameter
+  const portNum = port ? parseInt(port, 10) : NaN;
+  if (!port || isNaN(portNum) || portNum < 1024 || portNum > 65535) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="max-w-md mx-auto text-center p-8">
+          <h1 className="text-2xl font-bold text-red-600 mb-4">Invalid Request</h1>
+          <p className="text-gray-600">Missing or invalid port parameter. Please run <code className="bg-gray-100 px-2 py-1 rounded">fooshop login</code> again.</p>
+        </div>
+      </main>
+    );
+  }
+
+  // Check session
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent(`/cli-auth?port=${port}`)}`);
+  }
+
+  // Generate CSRF nonce
+  const nonce = crypto.randomUUID();
+  const cookieStore = await cookies();
+  cookieStore.set("cli-auth-nonce", nonce, {
+    httpOnly: true,
+    sameSite: "strict",
+    maxAge: 60,
+    path: "/api/auth/cli-callback",
+  });
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow-lg p-8 text-center">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold tracking-tight" style={{ fontFamily: "var(--font-display)" }}>
+            fooshop
+          </h1>
+        </div>
+
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          CLI wants to access your account
+        </h2>
+
+        <p className="text-gray-600 mb-6">
+          {session.user.name && <span>{session.user.name}<br /></span>}
+          Signed in as <strong>{session.user.email}</strong>
+        </p>
+
+        <p className="text-sm text-gray-500 mb-8">
+          This will create an API key with full access to your store, products, orders, and analytics.
+        </p>
+
+        <form method="POST" action="/api/auth/cli-callback">
+          <input type="hidden" name="port" value={port} />
+          <input type="hidden" name="nonce" value={nonce} />
+
+          <button
+            type="submit"
+            className="w-full bg-black text-white py-3 px-6 rounded-lg font-medium hover:bg-gray-800 transition-colors mb-3"
+          >
+            Approve
+          </button>
+        </form>
+
+        <a
+          href={`http://127.0.0.1:${port}/callback?error=denied`}
+          className="block w-full text-center py-3 px-6 rounded-lg font-medium text-gray-600 hover:bg-gray-100 transition-colors"
+        >
+          Deny
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/auth/cli-callback/route.ts
+++ b/src/app/api/auth/cli-callback/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { creators, apiKeys } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { generateApiKey, CREATOR_SCOPES } from "@/lib/api-key";
+import { cookies } from "next/headers";
+
+function generateSlug(email: string): string {
+  const prefix = email.split("@")[0]
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  const suffix = crypto.randomUUID().slice(0, 4);
+  return `${prefix}-${suffix}`;
+}
+
+export async function POST(req: NextRequest) {
+  // 1. Verify session
+  const session = await auth();
+  if (!session?.user?.id || !session.user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 2. Parse form data
+  const formData = await req.formData();
+  const nonce = formData.get("nonce") as string | null;
+  const portStr = formData.get("port") as string | null;
+
+  // 3. Validate CSRF nonce
+  const cookieStore = await cookies();
+  const cookieNonce = cookieStore.get("cli-auth-nonce")?.value;
+  cookieStore.delete("cli-auth-nonce");
+
+  if (!nonce || !cookieNonce || nonce !== cookieNonce) {
+    return NextResponse.json({ error: "Invalid or expired nonce" }, { status: 403 });
+  }
+
+  // 4. Validate port
+  const port = portStr ? parseInt(portStr, 10) : NaN;
+  if (isNaN(port) || port < 1024 || port > 65535) {
+    return NextResponse.json({ error: "Invalid port" }, { status: 400 });
+  }
+
+  // 5. Find or create creator
+  let creator = await db
+    .select()
+    .from(creators)
+    .where(eq(creators.userId, session.user.id))
+    .then((rows) => rows[0]);
+
+  if (!creator) {
+    const [newCreator] = await db
+      .insert(creators)
+      .values({
+        userId: session.user.id,
+        email: session.user.email,
+        name: session.user.name || session.user.email.split("@")[0],
+        slug: generateSlug(session.user.email),
+      })
+      .returning();
+    creator = newCreator;
+  }
+
+  // 6. Revoke existing CLI key (prevent accumulation)
+  await db
+    .delete(apiKeys)
+    .where(
+      and(eq(apiKeys.creatorId, creator.id), eq(apiKeys.name, "Fooshop CLI"))
+    );
+
+  // 7. Generate new API key
+  const { key, prefix, hash } = generateApiKey();
+  await db.insert(apiKeys).values({
+    creatorId: creator.id,
+    keyHash: hash,
+    keyPrefix: prefix,
+    name: "Fooshop CLI",
+    scopes: [...CREATOR_SCOPES],
+  });
+
+  // 8. Redirect to localhost callback
+  const redirectUrl = `http://127.0.0.1:${port}/callback?key=${encodeURIComponent(key)}&email=${encodeURIComponent(session.user.email)}`;
+  return NextResponse.redirect(redirectUrl, 302);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cli", "mcp-server"]
 }


### PR DESCRIPTION
Closes #81

## Summary

New `fooshop` CLI npm package with `fooshop login` browser-based auth flow.

### CLI Package (`cli/`)
- Commander.js + TypeScript (ESM, Node16)
- `fooshop login` — opens browser, authenticates via Google OAuth, receives API key via localhost callback
- Config at `~/.fooshop/config.json` with `FOOSHOP_API_KEY` and `FOOSHOP_BASE_URL` env var overrides
- 17 tests passing (config, server, login command)

### Web Endpoints
- `/cli-auth` — approval page with session check, CSRF nonce, native form POST
- `/api/auth/cli-callback` — generates API key, auto-creates creator if needed, redirects to localhost

### Security
- CSRF nonce in httpOnly cookie (60s TTL)
- Localhost callback server binds to 127.0.0.1 only
- Repeated logins revoke previous CLI key
- Port validation (1024-65535)

## Test plan
- [ ] `cd cli && pnpm test` — 17/17 passing
- [ ] `pnpm build` — clean build
- [ ] `pnpm test` — 130/130 existing tests pass (no regressions)
- [ ] Manual: `npx fooshop login` against staging