### PR TITLE
[Issue #84] CLI: core commands (init, products, orders, analytics)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -13,13 +13,19 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": ">=18"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.3.2",
+    "chalk": "^5.6.2",
+    "cli-table3": "^0.6.5",
     "commander": "^13.0.0",
-    "open": "^10.0.0"
+    "open": "^10.0.0",
+    "ora": "^9.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -8,12 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@inquirer/prompts':
+        specifier: ^8.3.2
+        version: 8.3.2(@types/node@20.19.37)
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
       commander:
         specifier: ^13.0.0
         version: 13.1.0
       open:
         specifier: ^10.0.0
         version: 10.2.0
+      ora:
+        specifier: ^9.3.0
+        version: 9.3.0
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -26,6 +38,10 @@ importers:
         version: 2.1.9(@types/node@20.19.37)
 
 packages:
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -164,6 +180,140 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/ansi@2.0.4':
+    resolution: {integrity: sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.2':
+    resolution: {integrity: sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.10':
+    resolution: {integrity: sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.7':
+    resolution: {integrity: sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.0.10':
+    resolution: {integrity: sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.10':
+    resolution: {integrity: sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@2.0.4':
+    resolution: {integrity: sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.4':
+    resolution: {integrity: sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.10':
+    resolution: {integrity: sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.10':
+    resolution: {integrity: sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.10':
+    resolution: {integrity: sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.3.2':
+    resolution: {integrity: sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.6':
+    resolution: {integrity: sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.6':
+    resolution: {integrity: sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.2':
+    resolution: {integrity: sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.4':
+    resolution: {integrity: sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -328,6 +478,14 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -344,9 +502,32 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -377,6 +558,9 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -392,24 +576,57 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -417,17 +634,33 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
+
+  ora@9.3.0:
+    resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
+    engines: {node: '>=20'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -443,6 +676,10 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -452,8 +689,15 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -464,6 +708,26 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stdin-discarder@0.3.1:
+    resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
+    engines: {node: '>=18'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -561,7 +825,14 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
 snapshots:
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -631,6 +902,125 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@inquirer/ansi@2.0.4': {}
+
+  '@inquirer/checkbox@5.1.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/confirm@6.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/core@11.1.7(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/editor@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/external-editor': 2.0.4(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/expand@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/external-editor@2.0.4(@types/node@20.19.37)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/figures@2.0.4': {}
+
+  '@inquirer/input@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/number@4.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/password@5.0.10(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/prompts@8.3.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.2(@types/node@20.19.37)
+      '@inquirer/confirm': 6.0.10(@types/node@20.19.37)
+      '@inquirer/editor': 5.0.10(@types/node@20.19.37)
+      '@inquirer/expand': 5.0.10(@types/node@20.19.37)
+      '@inquirer/input': 5.0.10(@types/node@20.19.37)
+      '@inquirer/number': 4.0.10(@types/node@20.19.37)
+      '@inquirer/password': 5.0.10(@types/node@20.19.37)
+      '@inquirer/rawlist': 5.2.6(@types/node@20.19.37)
+      '@inquirer/search': 4.1.6(@types/node@20.19.37)
+      '@inquirer/select': 5.1.2(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/rawlist@5.2.6(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/search@4.1.6(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/select@5.1.2(@types/node@20.19.37)':
+    dependencies:
+      '@inquirer/ansi': 2.0.4
+      '@inquirer/core': 11.1.7(@types/node@20.19.37)
+      '@inquirer/figures': 2.0.4
+      '@inquirer/type': 4.0.4(@types/node@20.19.37)
+    optionalDependencies:
+      '@types/node': 20.19.37
+
+  '@inquirer/type@4.0.4(@types/node@20.19.37)':
+    optionalDependencies:
+      '@types/node': 20.19.37
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -755,6 +1145,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   assertion-error@2.0.1: {}
 
   bundle-name@4.1.0:
@@ -771,7 +1165,25 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
+
   check-error@2.1.3: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@3.4.0: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cli-width@4.1.0: {}
 
   commander@13.1.0: {}
 
@@ -789,6 +1201,8 @@ snapshots:
       default-browser-id: 5.0.1
 
   define-lazy-prop@3.0.0: {}
+
+  emoji-regex@8.0.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -824,18 +1238,45 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fsevents@2.3.3:
     optional: true
 
+  get-east-asian-width@1.5.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   is-docker@3.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@2.0.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
   loupe@3.2.1: {}
 
@@ -843,9 +1284,17 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mimic-function@5.0.1: {}
+
   ms@2.1.3: {}
 
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.11: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   open@10.2.0:
     dependencies:
@@ -853,6 +1302,17 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  ora@9.3.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.1
+      string-width: 8.2.0
 
   pathe@1.1.2: {}
 
@@ -865,6 +1325,11 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   rollup@4.59.0:
     dependencies:
@@ -899,13 +1364,38 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  safer-buffer@2.1.2: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stdin-discarder@0.3.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   tinybench@2.9.0: {}
 
@@ -991,3 +1481,5 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  yoctocolors@2.1.2: {}

--- a/cli/src/__tests__/analytics.test.ts
+++ b/cli/src/__tests__/analytics.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop analytics", () => {
+  it("displays KPIs and tables", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          kpis: {
+            revenue: 15000,
+            orders: 5,
+            conversionRate: 3.2,
+            pageViews: 156,
+            changes: {
+              revenue: 25,
+              orders: 10,
+              conversionRate: -1.5,
+              pageViews: 30,
+            },
+          },
+          topProducts: [
+            { id: "1", title: "React Kit", sales: 3, revenue: 8700 },
+          ],
+          trafficSources: [
+            { source: "web", count: 100, percentage: 64.1 },
+            { source: "api", count: 56, percentage: 35.9 },
+          ],
+          revenueOverTime: [],
+          conversionFunnel: { pageViews: 156, buyIntents: 20, orders: 5 },
+          couponPerformance: [],
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { analyticsCommand } = await import("../commands/analytics.js");
+    await analyticsCommand.parseAsync([], { from: "user" });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("$150.00");
+    expect(output).toContain("React Kit");
+    consoleSpy.mockRestore();
+  });
+});

--- a/cli/src/__tests__/api.test.ts
+++ b/cli/src/__tests__/api.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Mock process.exit
+const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+// Mock console
+const mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+  mockExit.mockClear();
+  mockConsoleError.mockClear();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("api", () => {
+  it("sends GET with auth header", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: "test" }),
+    });
+
+    const result = await api.get("/api/products");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/products",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer fsk_testkey123",
+        }),
+      })
+    );
+    expect(result).toEqual({ data: "test" });
+  });
+
+  it("sends POST with body", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: "123" }),
+    });
+
+    const result = await api.post("/api/products", { title: "Test" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/products",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer fsk_testkey123",
+        }),
+        body: JSON.stringify({ title: "Test" }),
+      })
+    );
+    expect(result).toEqual({ id: "123" });
+  });
+
+  it("exits with error on 4xx/5xx response", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "Insufficient scope" }),
+    });
+
+    await expect(api.get("/api/products")).rejects.toThrow("process.exit called");
+    expect(mockConsoleError).toHaveBeenCalled();
+  });
+
+  it("exits when no API key configured", async () => {
+    vi.stubEnv("FOOSHOP_API_KEY", "");
+    vi.resetModules();
+
+    const { api } = await import("../lib/api.js");
+    await expect(api.get("/api/products")).rejects.toThrow("process.exit called");
+  });
+});

--- a/cli/src/__tests__/format.test.ts
+++ b/cli/src/__tests__/format.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+describe("formatPrice", () => {
+  it("formats cents to dollars", () => {
+    expect(formatPrice(2900)).toBe("$29.00");
+    expect(formatPrice(100)).toBe("$1.00");
+    expect(formatPrice(0)).toBe("$0.00");
+    expect(formatPrice(1999)).toBe("$19.99");
+  });
+});
+
+describe("buildTable", () => {
+  it("returns formatted table string", () => {
+    const result = buildTable(["Name", "Price"], [["Widget", "$10.00"]]);
+    expect(result).toContain("Name");
+    expect(result).toContain("Widget");
+    expect(result).toContain("$10.00");
+  });
+
+  it("handles empty rows", () => {
+    const result = buildTable(["Name"], []);
+    expect(result).toContain("Name");
+  });
+});

--- a/cli/src/__tests__/init.test.ts
+++ b/cli/src/__tests__/init.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("@inquirer/prompts", () => ({
+  input: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+vi.mock("open", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop init", () => {
+  it("generates a store from description", async () => {
+    const { input, confirm } = await import("@inquirer/prompts");
+    (input as ReturnType<typeof vi.fn>).mockResolvedValueOnce("Selling React templates");
+    (confirm as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          storeName: "React Templates Pro",
+          storeDescription: "Premium React templates",
+          slug: "react-templates-pro",
+          suggestedProducts: [],
+          theme: {},
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { initCommand } = await import("../commands/init.js");
+    await initCommand.parseAsync([], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/store/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ description: "Selling React templates" }),
+      })
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("react-templates-pro")
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/cli/src/__tests__/orders.test.ts
+++ b/cli/src/__tests__/orders.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop orders list", () => {
+  it("displays orders in a table", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          orders: [
+            {
+              id: "1",
+              createdAt: "2026-03-15T10:00:00Z",
+              productTitle: "React Kit",
+              amountCents: 2900,
+              platformFeeCents: 232,
+              currency: "usd",
+              buyerEmail: "buyer@test.com",
+              status: "completed",
+            },
+          ],
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { ordersCommand } = await import("../commands/orders.js");
+    await ordersCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("React Kit"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("buyer@test.com"));
+    consoleSpy.mockRestore();
+  });
+
+  it("passes period filter", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ orders: [] }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { ordersCommand } = await import("../commands/orders.js");
+    await ordersCommand.parseAsync(["list", "--last", "7d"], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("period=7d"),
+      expect.anything()
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/cli/src/__tests__/products.test.ts
+++ b/cli/src/__tests__/products.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("@inquirer/prompts", () => ({
+  input: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop products list", () => {
+  it("displays products in a table", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "1",
+            title: "React Kit",
+            slug: "react-kit",
+            priceCents: 2900,
+            status: "published",
+            creatorSlug: "my-store",
+          },
+        ]),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("React Kit"));
+    consoleSpy.mockRestore();
+  });
+
+  it("shows empty message when no products", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No products yet")
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("fooshop products delete", () => {
+  it("deletes a product after confirmation", async () => {
+    const { confirm } = await import("@inquirer/prompts");
+    (confirm as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+
+    // First call: GET products list to find by slug
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "1", title: "React Kit", slug: "react-kit", priceCents: 2900, status: "published" },
+        ]),
+    });
+    // Second call: DELETE
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["delete", "react-kit"], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("deleted"));
+    consoleSpy.mockRestore();
+  });
+});

--- a/cli/src/commands/analytics.ts
+++ b/cli/src/commands/analytics.ts
@@ -1,0 +1,82 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { api } from "../lib/api.js";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+interface AnalyticsResponse {
+  kpis: {
+    revenue: number;
+    orders: number;
+    conversionRate: number;
+    pageViews: number;
+    changes: {
+      revenue: number | null;
+      orders: number | null;
+      conversionRate: number | null;
+      pageViews: number | null;
+    };
+  };
+  topProducts: { id: string; title: string; sales: number; revenue: number }[];
+  trafficSources: { source: string; count: number; percentage: number }[];
+  revenueOverTime: { date: string; revenue: number }[];
+  conversionFunnel: { pageViews: number; buyIntents: number; orders: number };
+  couponPerformance: unknown[];
+}
+
+function formatChange(value: number | null): string {
+  if (value === null) return chalk.gray("—");
+  const sign = value >= 0 ? "+" : "";
+  const color = value >= 0 ? chalk.green : chalk.red;
+  return color(`${sign}${value.toFixed(1)}%`);
+}
+
+export const analyticsCommand = new Command("analytics")
+  .description("View store analytics")
+  .option("--period <period>", "Time period (7d, 30d, 90d, all)", "30d")
+  .action(async (opts) => {
+    const json = analyticsCommand.parent?.opts().json;
+    const data = await api.get<AnalyticsResponse>(
+      `/api/analytics?period=${opts.period}`
+    );
+
+    if (json) {
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+
+    const { kpis } = data;
+
+    console.log(chalk.bold("\n  Dashboard\n"));
+    console.log(
+      `  Revenue:      ${formatPrice(kpis.revenue)}  ${formatChange(kpis.changes.revenue)}`
+    );
+    console.log(
+      `  Orders:       ${kpis.orders}  ${formatChange(kpis.changes.orders)}`
+    );
+    console.log(
+      `  Conversion:   ${kpis.conversionRate.toFixed(1)}%  ${formatChange(kpis.changes.conversionRate)}`
+    );
+    console.log(
+      `  Page views:   ${kpis.pageViews}  ${formatChange(kpis.changes.pageViews)}`
+    );
+
+    if (data.topProducts.length > 0) {
+      console.log(chalk.bold("\n  Top Products\n"));
+      const rows = data.topProducts.slice(0, 5).map((p) => [
+        p.title,
+        String(p.sales),
+        formatPrice(p.revenue),
+      ]);
+      console.log(buildTable(["Product", "Sales", "Revenue"], rows));
+    }
+
+    if (data.trafficSources.length > 0) {
+      console.log(chalk.bold("\n  Traffic Sources\n"));
+      const rows = data.trafficSources.map((s) => [
+        s.source,
+        String(s.count),
+        `${s.percentage.toFixed(1)}%`,
+      ]);
+      console.log(buildTable(["Source", "Views", "Share"], rows));
+    }
+  });

--- a/cli/src/commands/config-cmd.ts
+++ b/cli/src/commands/config-cmd.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { readConfig, getBaseUrl } from "../lib/config.js";
+import { api } from "../lib/api.js";
+
+interface StoreInfo {
+  slug: string;
+  storeName: string;
+  stripeConnectId: string | null;
+}
+
+export const configCommand = new Command("config")
+  .description("Show current configuration")
+  .action(async () => {
+    const config = readConfig();
+    const baseUrl = getBaseUrl();
+
+    console.log(chalk.bold("\n  Configuration\n"));
+    console.log(`  Email:    ${config?.email || chalk.gray("Not logged in")}`);
+    console.log(`  API URL:  ${baseUrl}`);
+
+    try {
+      const store = await api.get<StoreInfo>("/api/store");
+      console.log(
+        `  Stripe:   ${store.stripeConnectId ? chalk.green("Connected") : chalk.yellow("Not connected")}`
+      );
+      console.log(`  Store:    ${baseUrl}/${store.slug}`);
+    } catch {
+      console.log(`  Store:    ${chalk.gray("Not set up yet. Run `fooshop init`")}`);
+    }
+
+    console.log();
+  });

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { input, confirm } from "@inquirer/prompts";
+import { api } from "../lib/api.js";
+import { spinner, successMsg, formatPrice } from "../lib/format.js";
+import { getBaseUrl } from "../lib/config.js";
+import { openBrowser } from "../lib/open.js";
+
+interface GeneratedStore {
+  storeName: string;
+  storeDescription: string;
+  slug: string;
+  suggestedProducts: {
+    title: string;
+    description: string;
+    suggestedPriceCents: number;
+    category: string;
+  }[];
+  theme: Record<string, unknown>;
+}
+
+export const initCommand = new Command("init")
+  .description("Create a new store with AI")
+  .action(async () => {
+    const description = await input({
+      message: "What are you selling?",
+    });
+
+    const s = spinner("Generating your store...");
+
+    let store: GeneratedStore;
+    try {
+      store = await api.post<GeneratedStore>("/api/store/generate", {
+        description,
+      });
+      s.succeed("Store generated!");
+    } catch {
+      s.fail("Failed to generate store");
+      return;
+    }
+
+    console.log();
+    console.log(`  Store:    ${store.storeName}`);
+    console.log(`  About:    ${store.storeDescription}`);
+    console.log(`  URL:      ${getBaseUrl()}/${store.slug}`);
+
+    if (store.suggestedProducts.length > 0) {
+      console.log();
+      console.log("  Suggested products:");
+      for (const p of store.suggestedProducts) {
+        console.log(`    - ${p.title} (${formatPrice(p.suggestedPriceCents)}) [${p.category}]`);
+      }
+    }
+
+    console.log();
+
+    const connectStripe = await confirm({
+      message: "Connect Stripe for payments?",
+      default: true,
+    });
+
+    if (connectStripe) {
+      await openBrowser(`${getBaseUrl()}/dashboard/settings`);
+      console.log("Complete Stripe setup in your browser.");
+    } else {
+      console.log("You can connect Stripe later with `fooshop config`.");
+    }
+
+    console.log();
+    successMsg(`Your store is live → ${getBaseUrl()}/${store.slug}`);
+  });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { api } from "../lib/api.js";
+import { getBaseUrl } from "../lib/config.js";
+import { openBrowser } from "../lib/open.js";
+import { successMsg } from "../lib/format.js";
+
+interface StoreInfo {
+  slug: string;
+}
+
+export const openCommand = new Command("open")
+  .description("Open your store in the browser")
+  .action(async () => {
+    const store = await api.get<StoreInfo>("/api/store");
+    const url = `${getBaseUrl()}/${store.slug}`;
+    await openBrowser(url);
+    successMsg(`Opening ${url}`);
+  });

--- a/cli/src/commands/orders.ts
+++ b/cli/src/commands/orders.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { api } from "../lib/api.js";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+interface Order {
+  id: string;
+  createdAt: string;
+  productTitle: string;
+  amountCents: number;
+  platformFeeCents: number;
+  currency: string;
+  buyerEmail: string;
+  status: string;
+}
+
+interface OrdersResponse {
+  orders: Order[];
+}
+
+export const ordersCommand = new Command("orders").description(
+  "Manage your orders"
+);
+
+ordersCommand
+  .command("list")
+  .description("List your orders")
+  .option("--last <period>", "Filter by period (7d, 30d, 90d)")
+  .action(async (opts) => {
+    const json = ordersCommand.parent?.opts().json;
+    const period = opts.last;
+    const query = period ? `?period=${period}` : "";
+    const data = await api.get<OrdersResponse>(`/api/orders${query}`);
+
+    if (json) {
+      console.log(JSON.stringify(data.orders, null, 2));
+      return;
+    }
+
+    if (data.orders.length === 0) {
+      console.log("No orders yet.");
+      return;
+    }
+
+    const rows = data.orders.map((o) => [
+      new Date(o.createdAt).toLocaleDateString(),
+      o.productTitle,
+      formatPrice(o.amountCents),
+      o.buyerEmail,
+    ]);
+
+    console.log(buildTable(["Date", "Product", "Amount", "Buyer"], rows));
+  });

--- a/cli/src/commands/products.ts
+++ b/cli/src/commands/products.ts
@@ -1,0 +1,266 @@
+import { Command } from "commander";
+import { input, select, confirm } from "@inquirer/prompts";
+import * as fs from "fs";
+import * as path from "path";
+import { api } from "../lib/api.js";
+import { spinner, successMsg, formatPrice, buildTable } from "../lib/format.js";
+import { getBaseUrl } from "../lib/config.js";
+
+interface Product {
+  id: string;
+  title: string;
+  slug: string;
+  description: string;
+  priceCents: number;
+  category: string;
+  status: string;
+  fileUrl?: string;
+  coverImageUrl?: string;
+  creatorSlug?: string;
+}
+
+interface UploadResponse {
+  uploadUrl: string;
+  key: string;
+}
+
+const CATEGORIES = [
+  "templates",
+  "presets",
+  "luts",
+  "prompts",
+  "guides",
+  "courses",
+  "assets",
+  "other",
+];
+
+async function uploadFile(
+  filePath: string,
+  purpose: "product" | "cover"
+): Promise<string> {
+  const filename = path.basename(filePath);
+  const ext = path.extname(filename).slice(1);
+  const contentTypeMap: Record<string, string> = {
+    zip: "application/zip",
+    pdf: "application/pdf",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    webp: "image/webp",
+    gif: "image/gif",
+  };
+  const contentType = contentTypeMap[ext] || "application/octet-stream";
+
+  const { uploadUrl, key } = await api.post<UploadResponse>("/api/upload", {
+    filename,
+    contentType,
+    purpose,
+  });
+
+  const fileBuffer = fs.readFileSync(filePath);
+  const res = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: fileBuffer,
+  });
+
+  if (!res.ok) {
+    console.error("File upload failed.");
+    process.exit(1);
+  }
+
+  return key;
+}
+
+export const productsCommand = new Command("products")
+  .description("Manage your products");
+
+// --- products list ---
+productsCommand
+  .command("list")
+  .description("List your products")
+  .action(async () => {
+    const json = productsCommand.parent?.opts().json;
+    const products = await api.get<Product[]>("/api/products?mine=true");
+
+    if (json) {
+      console.log(JSON.stringify(products, null, 2));
+      return;
+    }
+
+    if (products.length === 0) {
+      console.log("No products yet. Create one with `fooshop products add`.");
+      return;
+    }
+
+    const baseUrl = getBaseUrl();
+    const rows = products.map((p) => [
+      p.title,
+      formatPrice(p.priceCents),
+      p.status,
+      `${baseUrl}/${p.creatorSlug}/${p.slug}`,
+    ]);
+
+    console.log(buildTable(["Name", "Price", "Status", "URL"], rows));
+  });
+
+// --- products add ---
+productsCommand
+  .command("add")
+  .description("Add a new product")
+  .action(async () => {
+    const title = await input({ message: "Product name:" });
+
+    const priceStr = await input({
+      message: "Price (USD):",
+      validate: (v) => {
+        const n = parseFloat(v);
+        return !isNaN(n) && n >= 0 ? true : "Enter a valid price (e.g. 29.99)";
+      },
+    });
+    const priceCents = Math.round(parseFloat(priceStr) * 100);
+
+    const description = await input({ message: "Description:" });
+
+    const category = await select({
+      message: "Category:",
+      choices: CATEGORIES.map((c) => ({ name: c, value: c })),
+    });
+
+    const filePath = await input({
+      message: "Product file path:",
+      validate: (v) => (fs.existsSync(v) ? true : "File not found"),
+    });
+
+    const coverPath = await input({
+      message: "Cover image path (optional, press Enter to skip):",
+    });
+
+    const s = spinner("Uploading files...");
+
+    let fileUrl: string;
+    try {
+      fileUrl = await uploadFile(filePath, "product");
+    } catch {
+      s.fail("File upload failed");
+      return;
+    }
+
+    let coverImageUrl: string | undefined;
+    if (coverPath && coverPath.trim()) {
+      try {
+        coverImageUrl = await uploadFile(coverPath.trim(), "cover");
+      } catch {
+        s.fail("Cover upload failed");
+        return;
+      }
+    }
+
+    s.succeed("Files uploaded!");
+
+    const s2 = spinner("Creating product...");
+
+    try {
+      const product = await api.post<Product>("/api/products", {
+        title,
+        description,
+        priceCents,
+        category,
+        status: "published",
+        fileUrl,
+        coverImageUrl,
+      });
+
+      s2.succeed("Product created!");
+      const baseUrl = getBaseUrl();
+      successMsg(`${baseUrl}/${product.creatorSlug}/${product.slug}`);
+    } catch {
+      s2.fail("Failed to create product");
+    }
+  });
+
+// --- products edit ---
+productsCommand
+  .command("edit <slug>")
+  .description("Edit a product")
+  .action(async (slug: string) => {
+    const products = await api.get<Product[]>("/api/products?mine=true");
+    const product = products.find((p) => p.slug === slug);
+
+    if (!product) {
+      console.error(`Product "${slug}" not found.`);
+      process.exit(1);
+    }
+
+    console.log(`Editing: ${product.title} (${formatPrice(product.priceCents)})`);
+    console.log("Press Enter to keep current value.\n");
+
+    const title = await input({
+      message: "Product name:",
+      default: product.title,
+    });
+
+    const priceStr = await input({
+      message: "Price (USD):",
+      default: (product.priceCents / 100).toFixed(2),
+      validate: (v) => {
+        const n = parseFloat(v);
+        return !isNaN(n) && n >= 0 ? true : "Enter a valid price";
+      },
+    });
+    const priceCents = Math.round(parseFloat(priceStr) * 100);
+
+    const description = await input({
+      message: "Description:",
+      default: product.description,
+    });
+
+    const category = await select({
+      message: "Category:",
+      choices: CATEGORIES.map((c) => ({ name: c, value: c })),
+      default: product.category,
+    });
+
+    const s = spinner("Updating product...");
+    try {
+      await api.put(`/api/products/${product.id}`, {
+        title,
+        description,
+        priceCents,
+        category,
+      });
+      s.succeed("Product updated!");
+    } catch {
+      s.fail("Failed to update product");
+    }
+  });
+
+// --- products delete ---
+productsCommand
+  .command("delete <slug>")
+  .description("Delete a product")
+  .action(async (slug: string) => {
+    const products = await api.get<Product[]>("/api/products?mine=true");
+    const product = products.find((p) => p.slug === slug);
+
+    if (!product) {
+      console.error(`Product "${slug}" not found.`);
+      process.exit(1);
+    }
+
+    console.log(`${product.title} — ${formatPrice(product.priceCents)}`);
+
+    const yes = await confirm({
+      message: `Delete ${product.title}? This cannot be undone.`,
+      default: false,
+    });
+
+    if (!yes) {
+      console.log("Cancelled.");
+      return;
+    }
+
+    await api.del(`/api/products/${product.id}`);
+    successMsg("Product deleted");
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,14 +2,27 @@
 
 import { Command } from "commander";
 import { loginCommand } from "./commands/login.js";
+import { initCommand } from "./commands/init.js";
+import { productsCommand } from "./commands/products.js";
+import { ordersCommand } from "./commands/orders.js";
+import { analyticsCommand } from "./commands/analytics.js";
+import { configCommand } from "./commands/config-cmd.js";
+import { openCommand } from "./commands/open.js";
 
 const program = new Command();
 
 program
   .name("fooshop")
   .description("Fooshop CLI — commerce from your terminal")
-  .version("0.1.0");
+  .version("0.1.0")
+  .option("--json", "Output raw JSON (where supported)");
 
 program.addCommand(loginCommand);
+program.addCommand(initCommand);
+program.addCommand(productsCommand);
+program.addCommand(ordersCommand);
+program.addCommand(analyticsCommand);
+program.addCommand(configCommand);
+program.addCommand(openCommand);
 
 program.parse();

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,0 +1,49 @@
+import { getApiKey, getBaseUrl } from "./config.js";
+
+function ensureAuth(): string {
+  const key = getApiKey();
+  if (!key) {
+    console.error("Not logged in. Run `fooshop login` first.");
+    process.exit(1);
+  }
+  return key;
+}
+
+async function request<T>(method: string, path: string, body?: object): Promise<T> {
+  const key = ensureAuth();
+  const baseUrl = getBaseUrl();
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${key}`,
+  };
+
+  const init: RequestInit = { method, headers };
+
+  if (body) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}${path}`, init);
+  } catch {
+    console.error("Connection failed. Check your internet or try again.");
+    process.exit(1);
+  }
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+    console.error(data.error || `Request failed: ${res.status}`);
+    process.exit(1);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>("GET", path),
+  post: <T>(path: string, body: object) => request<T>("POST", path, body),
+  put: <T>(path: string, body: object) => request<T>("PUT", path, body),
+  del: <T>(path: string) => request<T>("DELETE", path),
+};

--- a/cli/src/lib/format.ts
+++ b/cli/src/lib/format.ts
@@ -1,0 +1,30 @@
+import chalk from "chalk";
+import ora, { type Ora } from "ora";
+import Table from "cli-table3";
+
+export function spinner(text: string): Ora {
+  return ora(text).start();
+}
+
+export function successMsg(text: string): void {
+  console.log(chalk.green(`✓ ${text}`));
+}
+
+export function errorMsg(text: string): void {
+  console.error(chalk.red(`✗ ${text}`));
+}
+
+export function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function buildTable(headers: string[], rows: string[][]): string {
+  const table = new Table({
+    head: headers.map((h) => chalk.cyan(h)),
+    style: { head: [], border: [] },
+  });
+  for (const row of rows) {
+    table.push(row);
+  }
+  return table.toString();
+}

--- a/docs/superpowers/plans/2026-03-20-cli-core-commands.md
+++ b/docs/superpowers/plans/2026-03-20-cli-core-commands.md
@@ -1,0 +1,1639 @@
+# CLI Core Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement 9 CLI commands (init, products add/list/edit/delete, orders list, analytics, config, open) plus a new `GET /api/orders` backend endpoint.
+
+**Architecture:** Flat command files in `cli/src/commands/`, shared HTTP client in `lib/api.ts`, formatting helpers in `lib/format.ts`. Each command is a Commander.js `Command` registered in `index.ts`. New backend endpoint follows existing `authenticateCreator` + Drizzle query pattern.
+
+**Tech Stack:** Commander.js, chalk, ora, cli-table3, @inquirer/prompts, vitest, Node.js fetch API
+
+**Worktree:** `/Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands`
+
+**Spec:** `docs/superpowers/specs/2026-03-20-cli-core-commands-design.md`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `cli/src/lib/api.ts` | HTTP client with auth, error handling |
+| Create | `cli/src/lib/format.ts` | chalk/ora/table helpers, price formatting |
+| Create | `cli/src/commands/init.ts` | `fooshop init` command |
+| Create | `cli/src/commands/products.ts` | `fooshop products add\|list\|edit\|delete` |
+| Create | `cli/src/commands/orders.ts` | `fooshop orders list` |
+| Create | `cli/src/commands/analytics.ts` | `fooshop analytics` |
+| Create | `cli/src/commands/config-cmd.ts` | `fooshop config` (named to avoid clash with lib/config.ts) |
+| Create | `cli/src/commands/open.ts` | `fooshop open` |
+| Create | `cli/src/__tests__/api.test.ts` | Tests for HTTP client |
+| Create | `cli/src/__tests__/format.test.ts` | Tests for format helpers |
+| Create | `cli/src/__tests__/init.test.ts` | Tests for init command |
+| Create | `cli/src/__tests__/products.test.ts` | Tests for products commands |
+| Create | `cli/src/__tests__/orders.test.ts` | Tests for orders command |
+| Create | `cli/src/__tests__/analytics.test.ts` | Tests for analytics command |
+| Create | `src/app/api/orders/route.ts` | `GET /api/orders` backend endpoint |
+| Modify | `cli/src/index.ts` | Register all new commands + `--json` global flag |
+| Modify | `cli/package.json` | Add chalk, ora, cli-table3, @inquirer/prompts |
+
+---
+
+## Task 1: Add dependencies
+
+**Files:**
+- Modify: `cli/package.json`
+
+- [ ] **Step 1: Install new dependencies**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm add chalk ora cli-table3 @inquirer/prompts
+pnpm add -D @types/cli-table3
+```
+
+- [ ] **Step 2: Verify build still works**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm build
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cli/package.json cli/pnpm-lock.yaml
+git commit -m "feat(cli): add chalk, ora, cli-table3, @inquirer/prompts (#84)"
+```
+
+---
+
+## Task 2: Shared HTTP client (`lib/api.ts`)
+
+**Files:**
+- Create: `cli/src/lib/api.ts`
+- Create: `cli/src/__tests__/api.test.ts`
+
+- [ ] **Step 1: Write failing tests for api.ts**
+
+Create `cli/src/__tests__/api.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Mock process.exit
+const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+// Mock console
+const mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+  mockExit.mockClear();
+  mockConsoleError.mockClear();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+describe("api", () => {
+  it("sends GET with auth header", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: "test" }),
+    });
+
+    const result = await api.get("/api/products");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/products",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer fsk_testkey123",
+        }),
+      })
+    );
+    expect(result).toEqual({ data: "test" });
+  });
+
+  it("sends POST with body", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: "123" }),
+    });
+
+    const result = await api.post("/api/products", { title: "Test" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/products",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer fsk_testkey123",
+        }),
+        body: JSON.stringify({ title: "Test" }),
+      })
+    );
+    expect(result).toEqual({ id: "123" });
+  });
+
+  it("exits with error on 4xx/5xx response", async () => {
+    const { api } = await import("../lib/api.js");
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "Insufficient scope" }),
+    });
+
+    await expect(api.get("/api/products")).rejects.toThrow("process.exit called");
+    expect(mockConsoleError).toHaveBeenCalled();
+  });
+
+  it("exits when no API key configured", async () => {
+    vi.stubEnv("FOOSHOP_API_KEY", "");
+    // Clear any cached modules
+    vi.resetModules();
+
+    const { api } = await import("../lib/api.js");
+    await expect(api.get("/api/products")).rejects.toThrow("process.exit called");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/api.test.ts
+```
+
+Expected: FAIL — `../lib/api.js` does not exist.
+
+- [ ] **Step 3: Implement api.ts**
+
+Create `cli/src/lib/api.ts`:
+
+```typescript
+import { getApiKey, getBaseUrl } from "./config.js";
+
+function ensureAuth(): string {
+  const key = getApiKey();
+  if (!key) {
+    console.error("Not logged in. Run `fooshop login` first.");
+    process.exit(1);
+  }
+  return key;
+}
+
+async function request<T>(method: string, path: string, body?: object): Promise<T> {
+  const key = ensureAuth();
+  const baseUrl = getBaseUrl();
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${key}`,
+  };
+
+  const init: RequestInit = { method, headers };
+
+  if (body) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}${path}`, init);
+  } catch {
+    console.error("Connection failed. Check your internet or try again.");
+    process.exit(1);
+  }
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+    console.error(data.error || `Request failed: ${res.status}`);
+    process.exit(1);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>("GET", path),
+  post: <T>(path: string, body: object) => request<T>("POST", path, body),
+  put: <T>(path: string, body: object) => request<T>("PUT", path, body),
+  del: <T>(path: string) => request<T>("DELETE", path),
+};
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/api.test.ts
+```
+
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/lib/api.ts cli/src/__tests__/api.test.ts
+git commit -m "feat(cli): add shared HTTP client with auth (#84)"
+```
+
+---
+
+## Task 3: Format helpers (`lib/format.ts`)
+
+**Files:**
+- Create: `cli/src/lib/format.ts`
+- Create: `cli/src/__tests__/format.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cli/src/__tests__/format.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+describe("formatPrice", () => {
+  it("formats cents to dollars", () => {
+    expect(formatPrice(2900)).toBe("$29.00");
+    expect(formatPrice(100)).toBe("$1.00");
+    expect(formatPrice(0)).toBe("$0.00");
+    expect(formatPrice(1999)).toBe("$19.99");
+  });
+});
+
+describe("buildTable", () => {
+  it("returns formatted table string", () => {
+    const result = buildTable(["Name", "Price"], [["Widget", "$10.00"]]);
+    expect(result).toContain("Name");
+    expect(result).toContain("Widget");
+    expect(result).toContain("$10.00");
+  });
+
+  it("handles empty rows", () => {
+    const result = buildTable(["Name"], []);
+    expect(result).toContain("Name");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/format.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement format.ts**
+
+Create `cli/src/lib/format.ts`:
+
+```typescript
+import chalk from "chalk";
+import ora, { type Ora } from "ora";
+import Table from "cli-table3";
+
+export function spinner(text: string): Ora {
+  return ora(text).start();
+}
+
+export function successMsg(text: string): void {
+  console.log(chalk.green(`✓ ${text}`));
+}
+
+export function errorMsg(text: string): void {
+  console.error(chalk.red(`✗ ${text}`));
+}
+
+export function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function buildTable(headers: string[], rows: string[][]): string {
+  const table = new Table({
+    head: headers.map((h) => chalk.cyan(h)),
+    style: { head: [], border: [] },
+  });
+  for (const row of rows) {
+    table.push(row);
+  }
+  return table.toString();
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/format.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/lib/format.ts cli/src/__tests__/format.test.ts
+git commit -m "feat(cli): add format helpers (chalk, ora, table, price) (#84)"
+```
+
+---
+
+## Task 4: Backend `GET /api/orders` endpoint
+
+**Files:**
+- Create: `src/app/api/orders/route.ts`
+
+- [ ] **Step 1: Implement the endpoint**
+
+Create `src/app/api/orders/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { orders, products } from "@/db/schema";
+import { eq, desc, gte, and } from "drizzle-orm";
+import { authenticateCreator } from "@/lib/api-key";
+
+export async function GET(req: NextRequest) {
+  const result = await authenticateCreator(req, "orders:read");
+  if (result instanceof NextResponse) return result;
+  const { creator } = result;
+
+  const period = req.nextUrl.searchParams.get("period") || "all";
+
+  const conditions = [eq(orders.creatorId, creator.id)];
+
+  if (period !== "all") {
+    const days = parseInt(period);
+    if (!isNaN(days)) {
+      const since = new Date();
+      since.setDate(since.getDate() - days);
+      conditions.push(gte(orders.createdAt, since));
+    }
+  }
+
+  const rows = await db
+    .select({
+      id: orders.id,
+      createdAt: orders.createdAt,
+      productTitle: products.title,
+      amountCents: orders.amountCents,
+      platformFeeCents: orders.platformFeeCents,
+      currency: products.currency,
+      buyerEmail: orders.buyerEmail,
+      status: orders.status,
+    })
+    .from(orders)
+    .innerJoin(products, eq(orders.productId, products.id))
+    .where(and(...conditions))
+    .orderBy(desc(orders.createdAt));
+
+  return NextResponse.json({ orders: rows });
+}
+```
+
+Note: The `period` param accepts `7d`, `30d`, `90d` — we parse the integer prefix. `all` skips the date filter.
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands
+pnpm build 2>&1 | tail -5
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/orders/route.ts
+git commit -m "feat(api): add GET /api/orders endpoint for creator orders (#84)"
+```
+
+---
+
+## Task 5: `fooshop init` command
+
+**Files:**
+- Create: `cli/src/commands/init.ts`
+- Create: `cli/src/__tests__/init.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cli/src/__tests__/init.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// Mock dependencies
+vi.mock("@inquirer/prompts", () => ({
+  input: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+vi.mock("open", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop init", () => {
+  it("generates a store from description", async () => {
+    const { input, confirm } = await import("@inquirer/prompts");
+    (input as ReturnType<typeof vi.fn>).mockResolvedValueOnce("Selling React templates");
+    (confirm as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          storeName: "React Templates Pro",
+          storeDescription: "Premium React templates",
+          slug: "react-templates-pro",
+          suggestedProducts: [],
+          theme: {},
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { initCommand } = await import("../commands/init.js");
+    await initCommand.parseAsync([], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://test.fooshop.ai/api/store/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ description: "Selling React templates" }),
+      })
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("react-templates-pro")
+    );
+    consoleSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/init.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement init.ts**
+
+Create `cli/src/commands/init.ts`:
+
+```typescript
+import { Command } from "commander";
+import { input, confirm } from "@inquirer/prompts";
+import { api } from "../lib/api.js";
+import { spinner, successMsg, formatPrice } from "../lib/format.js";
+import { getBaseUrl } from "../lib/config.js";
+import { openBrowser } from "../lib/open.js";
+
+interface GeneratedStore {
+  storeName: string;
+  storeDescription: string;
+  slug: string;
+  suggestedProducts: {
+    title: string;
+    description: string;
+    suggestedPriceCents: number;
+    category: string;
+  }[];
+  theme: Record<string, unknown>;
+}
+
+export const initCommand = new Command("init")
+  .description("Create a new store with AI")
+  .action(async () => {
+    const description = await input({
+      message: "What are you selling?",
+    });
+
+    const s = spinner("Generating your store...");
+
+    let store: GeneratedStore;
+    try {
+      store = await api.post<GeneratedStore>("/api/store/generate", {
+        description,
+      });
+      s.succeed("Store generated!");
+    } catch {
+      s.fail("Failed to generate store");
+      return;
+    }
+
+    console.log();
+    console.log(`  Store:    ${store.storeName}`);
+    console.log(`  About:    ${store.storeDescription}`);
+    console.log(`  URL:      ${getBaseUrl()}/${store.slug}`);
+
+    if (store.suggestedProducts.length > 0) {
+      console.log();
+      console.log("  Suggested products:");
+      for (const p of store.suggestedProducts) {
+        console.log(`    - ${p.title} (${formatPrice(p.suggestedPriceCents)}) [${p.category}]`);
+      }
+    }
+
+    console.log();
+
+    const connectStripe = await confirm({
+      message: "Connect Stripe for payments?",
+      default: true,
+    });
+
+    if (connectStripe) {
+      await openBrowser(`${getBaseUrl()}/dashboard/settings`);
+      console.log("Complete Stripe setup in your browser.");
+    } else {
+      console.log("You can connect Stripe later with `fooshop config`.");
+    }
+
+    console.log();
+    successMsg(`Your store is live → ${getBaseUrl()}/${store.slug}`);
+  });
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/init.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/commands/init.ts cli/src/__tests__/init.test.ts
+git commit -m "feat(cli): add fooshop init command (#84)"
+```
+
+---
+
+## Task 6: `fooshop products` command (add, list, edit, delete)
+
+**Files:**
+- Create: `cli/src/commands/products.ts`
+- Create: `cli/src/__tests__/products.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cli/src/__tests__/products.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("@inquirer/prompts", () => ({
+  input: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop products list", () => {
+  it("displays products in a table", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "1",
+            title: "React Kit",
+            slug: "react-kit",
+            priceCents: 2900,
+            status: "published",
+            creatorSlug: "my-store",
+          },
+        ]),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("React Kit"));
+    consoleSpy.mockRestore();
+  });
+
+  it("shows empty message when no products", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No products yet")
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("fooshop products delete", () => {
+  it("deletes a product after confirmation", async () => {
+    const { confirm } = await import("@inquirer/prompts");
+    (confirm as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+
+    // First call: GET products list to find by slug
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "1", title: "React Kit", slug: "react-kit", priceCents: 2900, status: "published" },
+        ]),
+    });
+    // Second call: DELETE
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { productsCommand } = await import("../commands/products.js");
+    await productsCommand.parseAsync(["delete", "react-kit"], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("deleted"));
+    consoleSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/products.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement products.ts**
+
+Create `cli/src/commands/products.ts`:
+
+```typescript
+import { Command } from "commander";
+import { input, select, confirm } from "@inquirer/prompts";
+import * as fs from "fs";
+import * as path from "path";
+import { api } from "../lib/api.js";
+import { spinner, successMsg, formatPrice, buildTable } from "../lib/format.js";
+import { getBaseUrl } from "../lib/config.js";
+
+interface Product {
+  id: string;
+  title: string;
+  slug: string;
+  description: string;
+  priceCents: number;
+  category: string;
+  status: string;
+  fileUrl?: string;
+  coverImageUrl?: string;
+  creatorSlug?: string;
+}
+
+interface UploadResponse {
+  uploadUrl: string;
+  key: string;
+}
+
+const CATEGORIES = [
+  "templates",
+  "presets",
+  "luts",
+  "prompts",
+  "guides",
+  "courses",
+  "assets",
+  "other",
+];
+
+async function uploadFile(
+  filePath: string,
+  purpose: "product" | "cover"
+): Promise<string> {
+  const filename = path.basename(filePath);
+  const ext = path.extname(filename).slice(1);
+  const contentTypeMap: Record<string, string> = {
+    zip: "application/zip",
+    pdf: "application/pdf",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    webp: "image/webp",
+    gif: "image/gif",
+  };
+  const contentType = contentTypeMap[ext] || "application/octet-stream";
+
+  const { uploadUrl, key } = await api.post<UploadResponse>("/api/upload", {
+    filename,
+    contentType,
+    purpose,
+  });
+
+  const fileBuffer = fs.readFileSync(filePath);
+  const res = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: fileBuffer,
+  });
+
+  if (!res.ok) {
+    console.error("File upload failed.");
+    process.exit(1);
+  }
+
+  return key;
+}
+
+export const productsCommand = new Command("products")
+  .description("Manage your products");
+
+// --- products list ---
+productsCommand
+  .command("list")
+  .description("List your products")
+  .action(async () => {
+    const json = productsCommand.parent?.opts().json;
+    const products = await api.get<Product[]>("/api/products?mine=true");
+
+    if (json) {
+      console.log(JSON.stringify(products, null, 2));
+      return;
+    }
+
+    if (products.length === 0) {
+      console.log("No products yet. Create one with `fooshop products add`.");
+      return;
+    }
+
+    const baseUrl = getBaseUrl();
+    const rows = products.map((p) => [
+      p.title,
+      formatPrice(p.priceCents),
+      p.status,
+      `${baseUrl}/${p.creatorSlug}/${p.slug}`,
+    ]);
+
+    console.log(buildTable(["Name", "Price", "Status", "URL"], rows));
+  });
+
+// --- products add ---
+productsCommand
+  .command("add")
+  .description("Add a new product")
+  .action(async () => {
+    const title = await input({ message: "Product name:" });
+
+    const priceStr = await input({
+      message: "Price (USD):",
+      validate: (v) => {
+        const n = parseFloat(v);
+        return !isNaN(n) && n >= 0 ? true : "Enter a valid price (e.g. 29.99)";
+      },
+    });
+    const priceCents = Math.round(parseFloat(priceStr) * 100);
+
+    const description = await input({ message: "Description:" });
+
+    const category = await select({
+      message: "Category:",
+      choices: CATEGORIES.map((c) => ({ name: c, value: c })),
+    });
+
+    const filePath = await input({
+      message: "Product file path:",
+      validate: (v) => (fs.existsSync(v) ? true : "File not found"),
+    });
+
+    const coverPath = await input({
+      message: "Cover image path (optional, press Enter to skip):",
+    });
+
+    const s = spinner("Uploading files...");
+
+    let fileUrl: string;
+    try {
+      fileUrl = await uploadFile(filePath, "product");
+    } catch {
+      s.fail("File upload failed");
+      return;
+    }
+
+    let coverImageUrl: string | undefined;
+    if (coverPath && coverPath.trim()) {
+      try {
+        coverImageUrl = await uploadFile(coverPath.trim(), "cover");
+      } catch {
+        s.fail("Cover upload failed");
+        return;
+      }
+    }
+
+    s.succeed("Files uploaded!");
+
+    const s2 = spinner("Creating product...");
+
+    try {
+      const product = await api.post<Product>("/api/products", {
+        title,
+        description,
+        priceCents,
+        category,
+        status: "published",
+        fileUrl,
+        coverImageUrl,
+      });
+
+      s2.succeed("Product created!");
+      const baseUrl = getBaseUrl();
+      successMsg(`${baseUrl}/${product.creatorSlug}/${product.slug}`);
+    } catch {
+      s2.fail("Failed to create product");
+    }
+  });
+
+// --- products edit ---
+productsCommand
+  .command("edit <slug>")
+  .description("Edit a product")
+  .action(async (slug: string) => {
+    const products = await api.get<Product[]>("/api/products?mine=true");
+    const product = products.find((p) => p.slug === slug);
+
+    if (!product) {
+      console.error(`Product "${slug}" not found.`);
+      process.exit(1);
+    }
+
+    console.log(`Editing: ${product.title} (${formatPrice(product.priceCents)})`);
+    console.log("Press Enter to keep current value.\n");
+
+    const title = await input({
+      message: "Product name:",
+      default: product.title,
+    });
+
+    const priceStr = await input({
+      message: "Price (USD):",
+      default: (product.priceCents / 100).toFixed(2),
+      validate: (v) => {
+        const n = parseFloat(v);
+        return !isNaN(n) && n >= 0 ? true : "Enter a valid price";
+      },
+    });
+    const priceCents = Math.round(parseFloat(priceStr) * 100);
+
+    const description = await input({
+      message: "Description:",
+      default: product.description,
+    });
+
+    const category = await select({
+      message: "Category:",
+      choices: CATEGORIES.map((c) => ({ name: c, value: c })),
+      default: product.category,
+    });
+
+    const s = spinner("Updating product...");
+    try {
+      await api.put(`/api/products/${product.id}`, {
+        title,
+        description,
+        priceCents,
+        category,
+      });
+      s.succeed("Product updated!");
+    } catch {
+      s.fail("Failed to update product");
+    }
+  });
+
+// --- products delete ---
+productsCommand
+  .command("delete <slug>")
+  .description("Delete a product")
+  .action(async (slug: string) => {
+    const products = await api.get<Product[]>("/api/products?mine=true");
+    const product = products.find((p) => p.slug === slug);
+
+    if (!product) {
+      console.error(`Product "${slug}" not found.`);
+      process.exit(1);
+    }
+
+    console.log(`${product.title} — ${formatPrice(product.priceCents)}`);
+
+    const yes = await confirm({
+      message: `Delete ${product.title}? This cannot be undone.`,
+      default: false,
+    });
+
+    if (!yes) {
+      console.log("Cancelled.");
+      return;
+    }
+
+    await api.del(`/api/products/${product.id}`);
+    successMsg("Product deleted");
+  });
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/products.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/commands/products.ts cli/src/__tests__/products.test.ts
+git commit -m "feat(cli): add fooshop products add/list/edit/delete commands (#84)"
+```
+
+---
+
+## Task 7: `fooshop orders list` command
+
+**Files:**
+- Create: `cli/src/commands/orders.ts`
+- Create: `cli/src/__tests__/orders.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cli/src/__tests__/orders.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop orders list", () => {
+  it("displays orders in a table", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          orders: [
+            {
+              id: "1",
+              createdAt: "2026-03-15T10:00:00Z",
+              productTitle: "React Kit",
+              amountCents: 2900,
+              platformFeeCents: 232,
+              currency: "usd",
+              buyerEmail: "buyer@test.com",
+              status: "completed",
+            },
+          ],
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { ordersCommand } = await import("../commands/orders.js");
+    await ordersCommand.parseAsync(["list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("React Kit"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("buyer@test.com"));
+    consoleSpy.mockRestore();
+  });
+
+  it("passes period filter", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ orders: [] }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { ordersCommand } = await import("../commands/orders.js");
+    await ordersCommand.parseAsync(["list", "--last", "7d"], { from: "user" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("period=7d"),
+      expect.anything()
+    );
+    consoleSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/orders.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement orders.ts**
+
+Create `cli/src/commands/orders.ts`:
+
+```typescript
+import { Command } from "commander";
+import { api } from "../lib/api.js";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+interface Order {
+  id: string;
+  createdAt: string;
+  productTitle: string;
+  amountCents: number;
+  platformFeeCents: number;
+  currency: string;
+  buyerEmail: string;
+  status: string;
+}
+
+interface OrdersResponse {
+  orders: Order[];
+}
+
+export const ordersCommand = new Command("orders").description(
+  "Manage your orders"
+);
+
+ordersCommand
+  .command("list")
+  .description("List your orders")
+  .option("--last <period>", "Filter by period (7d, 30d, 90d)")
+  .action(async (opts) => {
+    const json = ordersCommand.parent?.opts().json;
+    const period = opts.last;
+    const query = period ? `?period=${period}` : "";
+    const data = await api.get<OrdersResponse>(`/api/orders${query}`);
+
+    if (json) {
+      console.log(JSON.stringify(data.orders, null, 2));
+      return;
+    }
+
+    if (data.orders.length === 0) {
+      console.log("No orders yet.");
+      return;
+    }
+
+    const rows = data.orders.map((o) => [
+      new Date(o.createdAt).toLocaleDateString(),
+      o.productTitle,
+      formatPrice(o.amountCents),
+      o.buyerEmail,
+    ]);
+
+    console.log(buildTable(["Date", "Product", "Amount", "Buyer"], rows));
+  });
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/orders.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/commands/orders.ts cli/src/__tests__/orders.test.ts
+git commit -m "feat(cli): add fooshop orders list command (#84)"
+```
+
+---
+
+## Task 8: `fooshop analytics` command
+
+**Files:**
+- Create: `cli/src/commands/analytics.ts`
+- Create: `cli/src/__tests__/analytics.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cli/src/__tests__/analytics.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+vi.mock("ora", () => {
+  const spinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  };
+  return { default: vi.fn(() => spinner) };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fooshop-test-"));
+  vi.stubEnv("FOOSHOP_CONFIG_DIR", tmpDir);
+  vi.stubEnv("FOOSHOP_BASE_URL", "https://test.fooshop.ai");
+  vi.stubEnv("FOOSHOP_API_KEY", "fsk_testkey123");
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("fooshop analytics", () => {
+  it("displays KPIs and tables", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          kpis: {
+            revenue: 15000,
+            orders: 5,
+            conversionRate: 3.2,
+            pageViews: 156,
+            changes: {
+              revenue: 25,
+              orders: 10,
+              conversionRate: -1.5,
+              pageViews: 30,
+            },
+          },
+          topProducts: [
+            { id: "1", title: "React Kit", sales: 3, revenue: 8700 },
+          ],
+          trafficSources: [
+            { source: "web", count: 100, percentage: 64.1 },
+            { source: "api", count: 56, percentage: 35.9 },
+          ],
+          revenueOverTime: [],
+          conversionFunnel: { pageViews: 156, buyIntents: 20, orders: 5 },
+          couponPerformance: [],
+        }),
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { analyticsCommand } = await import("../commands/analytics.js");
+    await analyticsCommand.parseAsync([], { from: "user" });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("$150.00");
+    expect(output).toContain("React Kit");
+    consoleSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/analytics.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement analytics.ts**
+
+Create `cli/src/commands/analytics.ts`:
+
+```typescript
+import { Command } from "commander";
+import chalk from "chalk";
+import { api } from "../lib/api.js";
+import { formatPrice, buildTable } from "../lib/format.js";
+
+interface AnalyticsResponse {
+  kpis: {
+    revenue: number;
+    orders: number;
+    conversionRate: number;
+    pageViews: number;
+    changes: {
+      revenue: number | null;
+      orders: number | null;
+      conversionRate: number | null;
+      pageViews: number | null;
+    };
+  };
+  topProducts: { id: string; title: string; sales: number; revenue: number }[];
+  trafficSources: { source: string; count: number; percentage: number }[];
+  revenueOverTime: { date: string; revenue: number }[];
+  conversionFunnel: { pageViews: number; buyIntents: number; orders: number };
+  couponPerformance: unknown[];
+}
+
+function formatChange(value: number | null): string {
+  if (value === null) return chalk.gray("—");
+  const sign = value >= 0 ? "+" : "";
+  const color = value >= 0 ? chalk.green : chalk.red;
+  return color(`${sign}${value.toFixed(1)}%`);
+}
+
+export const analyticsCommand = new Command("analytics")
+  .description("View store analytics")
+  .option("--period <period>", "Time period (7d, 30d, 90d, all)", "30d")
+  .action(async (opts) => {
+    const json = analyticsCommand.parent?.opts().json;
+    const data = await api.get<AnalyticsResponse>(
+      `/api/analytics?period=${opts.period}`
+    );
+
+    if (json) {
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+
+    const { kpis } = data;
+
+    console.log(chalk.bold("\n  Dashboard\n"));
+    console.log(
+      `  Revenue:      ${formatPrice(kpis.revenue)}  ${formatChange(kpis.changes.revenue)}`
+    );
+    console.log(
+      `  Orders:       ${kpis.orders}  ${formatChange(kpis.changes.orders)}`
+    );
+    console.log(
+      `  Conversion:   ${kpis.conversionRate.toFixed(1)}%  ${formatChange(kpis.changes.conversionRate)}`
+    );
+    console.log(
+      `  Page views:   ${kpis.pageViews}  ${formatChange(kpis.changes.pageViews)}`
+    );
+
+    if (data.topProducts.length > 0) {
+      console.log(chalk.bold("\n  Top Products\n"));
+      const rows = data.topProducts.slice(0, 5).map((p) => [
+        p.title,
+        String(p.sales),
+        formatPrice(p.revenue),
+      ]);
+      console.log(buildTable(["Product", "Sales", "Revenue"], rows));
+    }
+
+    if (data.trafficSources.length > 0) {
+      console.log(chalk.bold("\n  Traffic Sources\n"));
+      const rows = data.trafficSources.map((s) => [
+        s.source,
+        String(s.count),
+        `${s.percentage.toFixed(1)}%`,
+      ]);
+      console.log(buildTable(["Source", "Views", "Share"], rows));
+    }
+  });
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test -- src/__tests__/analytics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/commands/analytics.ts cli/src/__tests__/analytics.test.ts
+git commit -m "feat(cli): add fooshop analytics command (#84)"
+```
+
+---
+
+## Task 9: `fooshop config` and `fooshop open` commands
+
+**Files:**
+- Create: `cli/src/commands/config-cmd.ts`
+- Create: `cli/src/commands/open.ts`
+
+- [ ] **Step 1: Implement config-cmd.ts**
+
+Create `cli/src/commands/config-cmd.ts`:
+
+```typescript
+import { Command } from "commander";
+import chalk from "chalk";
+import { readConfig, getBaseUrl } from "../lib/config.js";
+import { api } from "../lib/api.js";
+
+interface StoreInfo {
+  slug: string;
+  storeName: string;
+  stripeConnectId: string | null;
+}
+
+export const configCommand = new Command("config")
+  .description("Show current configuration")
+  .action(async () => {
+    const config = readConfig();
+    const baseUrl = getBaseUrl();
+
+    console.log(chalk.bold("\n  Configuration\n"));
+    console.log(`  Email:    ${config?.email || chalk.gray("Not logged in")}`);
+    console.log(`  API URL:  ${baseUrl}`);
+
+    try {
+      const store = await api.get<StoreInfo>("/api/store");
+      console.log(
+        `  Stripe:   ${store.stripeConnectId ? chalk.green("Connected") : chalk.yellow("Not connected")}`
+      );
+      console.log(`  Store:    ${baseUrl}/${store.slug}`);
+    } catch {
+      console.log(`  Store:    ${chalk.gray("Not set up yet. Run `fooshop init`")}`);
+    }
+
+    console.log();
+  });
+```
+
+- [ ] **Step 2: Implement open.ts command**
+
+Create `cli/src/commands/open.ts`:
+
+```typescript
+import { Command } from "commander";
+import { api } from "../lib/api.js";
+import { getBaseUrl } from "../lib/config.js";
+import { openBrowser } from "../lib/open.js";
+import { successMsg } from "../lib/format.js";
+
+interface StoreInfo {
+  slug: string;
+}
+
+export const openCommand = new Command("open")
+  .description("Open your store in the browser")
+  .action(async () => {
+    const store = await api.get<StoreInfo>("/api/store");
+    const url = `${getBaseUrl()}/${store.slug}`;
+    await openBrowser(url);
+    successMsg(`Opening ${url}`);
+  });
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/commands/config-cmd.ts cli/src/commands/open.ts
+git commit -m "feat(cli): add fooshop config and open commands (#84)"
+```
+
+---
+
+## Task 10: Register all commands in index.ts + `--json` flag
+
+**Files:**
+- Modify: `cli/src/index.ts`
+
+- [ ] **Step 1: Update index.ts**
+
+Replace the content of `cli/src/index.ts` with:
+
+```typescript
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { loginCommand } from "./commands/login.js";
+import { initCommand } from "./commands/init.js";
+import { productsCommand } from "./commands/products.js";
+import { ordersCommand } from "./commands/orders.js";
+import { analyticsCommand } from "./commands/analytics.js";
+import { configCommand } from "./commands/config-cmd.js";
+import { openCommand } from "./commands/open.js";
+
+const program = new Command();
+
+program
+  .name("fooshop")
+  .description("Fooshop CLI — commerce from your terminal")
+  .version("0.1.0")
+  .option("--json", "Output raw JSON (where supported)");
+
+program.addCommand(loginCommand);
+program.addCommand(initCommand);
+program.addCommand(productsCommand);
+program.addCommand(ordersCommand);
+program.addCommand(analyticsCommand);
+program.addCommand(configCommand);
+program.addCommand(openCommand);
+
+program.parse();
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm build
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Verify help output**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+node dist/index.js --help
+```
+
+Expected: Shows all commands (login, init, products, orders, analytics, config, open).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/index.ts
+git commit -m "feat(cli): register all commands and add --json global flag (#84)"
+```
+
+---
+
+## Task 11: Full build verification
+
+- [ ] **Step 1: Run full Next.js build to verify backend endpoint**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands
+pnpm build 2>&1 | tail -10
+```
+
+Expected: Build succeeds, `/api/orders` shows in route list.
+
+- [ ] **Step 2: Run CLI test suite**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+pnpm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Verify `fooshop --help` shows all commands**
+
+```bash
+cd /Users/ematomax/Documents/fooshop/.worktrees/feat/issue-84-cli-core-commands/cli
+node dist/index.js --help
+node dist/index.js products --help
+node dist/index.js orders --help
+```
+
+Expected: All help output correct with descriptions.

--- a/docs/superpowers/specs/2026-03-20-cli-core-commands-design.md
+++ b/docs/superpowers/specs/2026-03-20-cli-core-commands-design.md
@@ -1,0 +1,228 @@
+# CLI Core Commands Design
+
+**Issue:** #84
+**Date:** 2026-03-20
+**Status:** Approved
+
+## Overview
+
+Implement the 9 core CLI commands that make `fooshop` a complete interface for managing a store: `init`, `products add/list/edit/delete`, `orders list`, `analytics`, `config`, `open`.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | All 9 commands in one issue | Full CLI experience in one shot |
+| Architecture | Flat commands (Approach A) | Follows existing `login.ts` pattern, simple, YAGNI |
+| UX libs | chalk + ora + cli-table3 + @inquirer/prompts | Full UX polish; CLI is the primary interface |
+| Upload progress | Spinner (ora), no progress bar | YAGNI — most files under 50MB |
+| Stripe onboarding | Open browser to dashboard | Stripe onboarding is a browser flow regardless |
+| Orders endpoint | Create new `GET /api/orders` | Clean JSON API, no CSV parsing workaround |
+
+## File Structure
+
+### New files
+
+```
+cli/src/
+  commands/
+    init.ts           # fooshop init
+    products.ts       # fooshop products add|list|edit|delete
+    orders.ts         # fooshop orders list
+    analytics.ts      # fooshop analytics
+    config.ts         # fooshop config (command, not lib/config.ts)
+    open.ts           # fooshop open (command, not lib/open.ts)
+  lib/
+    api.ts            # HTTP client with auth
+    format.ts         # Chalk helpers, table builder, spinner wrapper
+
+src/app/api/orders/route.ts   # New backend endpoint
+```
+
+### Modified files
+
+- `cli/src/index.ts` — register 6 new commands
+- `cli/package.json` — add new dependencies
+
+### New dependencies
+
+| Package | Purpose |
+|---------|---------|
+| chalk | Colored terminal output |
+| ora | Async spinners |
+| cli-table3 | Formatted tables |
+| @inquirer/prompts | Interactive input prompts |
+
+## Shared Libraries
+
+### `lib/api.ts` — HTTP Client
+
+Wrapper around `fetch` centralizing auth, base URL, and error handling.
+
+**Interface:**
+```typescript
+api.get(path: string): Promise<T>
+api.post(path: string, body: object): Promise<T>
+api.put(path: string, body: object): Promise<T>
+api.del(path: string): Promise<T>
+```
+
+**Behavior:**
+- Reads API key from `getApiKey()`. If null, prints "Not logged in. Run `fooshop login` first." and exits with code 1.
+- Sets `Authorization: Bearer <key>` on every request.
+- Base URL from `getBaseUrl()`.
+- Content-Type: `application/json`.
+- On non-ok response (4xx/5xx): parses JSON body, prints server error message in red, exits with code 1.
+- On network error: prints "Connection failed. Check your internet or try again.", exits with code 1.
+
+### `lib/format.ts` — Output Helpers
+
+```typescript
+spinner(text: string): Ora         // wrapper on ora
+successMsg(text: string): void     // chalk.green("✓ " + text)
+errorMsg(text: string): void       // chalk.red("✗ " + text)
+table(headers: string[], rows: string[][]): string  // cli-table3 formatted
+formatPrice(cents: number): string // cents → "$X.XX"
+```
+
+## Commands
+
+### `fooshop init`
+
+1. Verify auth (API key present, else "Run `fooshop login` first")
+2. Prompt: "What are you selling?" (single free-text input)
+3. Spinner: "Generating your store..."
+4. `POST /api/store/generate` with `{ description: answer }`
+5. Display result: store name, tagline, slug, suggested products
+6. Prompt: "Connect Stripe for payments?" (confirm y/n)
+   - Yes: open browser to `{baseUrl}/dashboard/settings`, message "Complete Stripe setup in browser"
+   - No: skip, message "You can connect Stripe later with `fooshop config`"
+7. Output: `✓ Your store is live → https://fooshop.ai/<slug>`
+
+### `fooshop products add`
+
+Sequential prompts (one at a time):
+1. "Product name:" (text input)
+2. "Price (USD):" (text input, numeric validation, converted to cents)
+3. "Description:" (text input)
+4. "Category:" (select from supported categories)
+5. "Product file path:" (text input, file existence validation)
+6. "Cover image path (optional):" (text input, skip if empty)
+7. Upload file: `POST /api/upload` for presigned URL, then `PUT` to R2 (spinner)
+8. Upload cover if present (same flow)
+9. `POST /api/products` with all data, status: `published`
+10. Output: `✓ Product created → https://fooshop.ai/<store-slug>/<product-slug>`
+
+### `fooshop products list`
+
+1. `GET /api/products?mine=true`
+2. Table: Name | Price | Status | URL
+3. If no products: "No products yet. Create one with `fooshop products add`"
+4. `--json` flag: raw JSON output
+
+### `fooshop products edit <slug>`
+
+1. `GET /api/products?mine=true`, find by slug
+2. Show current values
+3. Prompt for each field (pre-filled with current value, enter to keep)
+4. `PUT /api/products/[id]` with changed fields only
+5. Output: `✓ Product updated`
+
+### `fooshop products delete <slug>`
+
+1. `GET /api/products?mine=true`, find by slug
+2. Show name and price
+3. Confirm prompt: "Delete <name>? This cannot be undone." (y/n)
+4. `DELETE /api/products/[id]`
+5. Output: `✓ Product deleted`
+
+### `fooshop orders list`
+
+1. `GET /api/orders` (new endpoint)
+2. Table: Date | Product | Amount | Buyer email
+3. `--last 7d|30d|90d` flag: query param `period`
+4. `--json` flag: raw JSON output
+5. If no orders: "No orders yet."
+
+### `fooshop analytics`
+
+1. `GET /api/analytics?period=30d`
+2. Display KPIs: Revenue | Orders | Conversion | Page views (with change %)
+3. Top products table (top 5)
+4. Traffic sources table
+5. `--period 7d|30d|90d|all` flag
+6. `--json` flag: raw JSON output
+
+### `fooshop config`
+
+No arguments — shows current config:
+```
+Email:    user@example.com
+API URL:  https://fooshop.ai
+Stripe:   Connected / Not connected
+Store:    https://fooshop.ai/my-store
+```
+Reads email/baseUrl from local config, store/stripe info from `GET /api/store`.
+
+### `fooshop open`
+
+1. Read store slug from `GET /api/store`
+2. Open `https://fooshop.ai/<slug>` in browser
+3. Output: `✓ Opening https://fooshop.ai/<slug>`
+
+## New Backend Endpoint
+
+### `GET /api/orders`
+
+**Auth:** API key with scope `orders:read`
+
+**Query params:**
+- `period` — `7d`, `30d`, `90d`, `all` (default: `all`)
+
+**Response:**
+```json
+{
+  "orders": [
+    {
+      "id": "uuid",
+      "createdAt": "2026-03-15T...",
+      "productTitle": "My Template",
+      "amountCents": 2900,
+      "platformFeeCents": 232,
+      "currency": "usd",
+      "buyerEmail": "buyer@example.com",
+      "status": "completed"
+    }
+  ]
+}
+```
+
+**Implementation:** Join `orders` with `products`, filter by `creatorId` from auth token. Period filter via `WHERE createdAt >= NOW() - interval`. Ordered by `createdAt DESC`.
+
+## `--json` Flag
+
+Global option on `program` in `index.ts`. Commands that support it (`products list`, `orders list`, `analytics`) check `program.opts().json` — if true, output `JSON.stringify(data, null, 2)` and skip table/formatting.
+
+## Testing Strategy
+
+**Unit tests for libs:**
+- `lib/api.ts` — mock fetch, test auth header injection, error handling, exit on 401
+- `lib/format.ts` — test formatPrice, table output
+
+**Integration tests for commands:**
+- `commands/init.ts` — mock api + @inquirer/prompts, verify full flow
+- `commands/products.ts` — mock api, test add/list/edit/delete
+- `commands/orders.ts` — mock api, test list + period filter
+- `commands/analytics.ts` — mock api, test KPI output
+
+**Backend test:**
+- `GET /api/orders` — test with existing API route test patterns
+
+**Mocking approach:** Mock `@inquirer/prompts` with `vi.mock()` to simulate user input. Mock `ora` to avoid spinner output in tests. Same strategy as existing `login.test.ts`.
+
+## Out of Scope
+
+- Progress bar for file uploads (YAGNI)
+- `fooshop products add --file` non-interactive mode (future)
+- API key management commands (separate issue)
+- Coupons/referrals CLI commands (separate issue)

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { orders, products } from "@/db/schema";
+import { eq, desc, gte, and } from "drizzle-orm";
+import { authenticateCreator } from "@/lib/api-key";
+
+export async function GET(req: NextRequest) {
+  const result = await authenticateCreator(req, "orders:read");
+  if (result instanceof NextResponse) return result;
+  const { creator } = result;
+
+  const period = req.nextUrl.searchParams.get("period") || "all";
+
+  const conditions = [eq(orders.creatorId, creator.id)];
+
+  if (period !== "all") {
+    const days = parseInt(period);
+    if (!isNaN(days)) {
+      const since = new Date();
+      since.setDate(since.getDate() - days);
+      conditions.push(gte(orders.createdAt, since));
+    }
+  }
+
+  const rows = await db
+    .select({
+      id: orders.id,
+      createdAt: orders.createdAt,
+      productTitle: products.title,
+      amountCents: orders.amountCents,
+      platformFeeCents: orders.platformFeeCents,
+      currency: products.currency,
+      buyerEmail: orders.buyerEmail,
+      status: orders.status,
+    })
+    .from(orders)
+    .innerJoin(products, eq(orders.productId, products.id))
+    .where(and(...conditions))
+    .orderBy(desc(orders.createdAt));
+
+  return NextResponse.json({ orders: rows });
+}


### PR DESCRIPTION
Closes #84

## Summary
- Add 9 CLI commands: `init`, `products add/list/edit/delete`, `orders list`, `analytics`, `config`, `open`
- Add shared HTTP client (`lib/api.ts`) with auth and error handling
- Add format helpers (`lib/format.ts`) with chalk, ora, cli-table3
- Add `GET /api/orders` backend endpoint for creator orders with period filtering
- Add `--json` global flag for scriptable output
- New dependencies: chalk, ora, cli-table3, @inquirer/prompts

## Test plan
- [ ] `fooshop --help` shows all 7 commands
- [ ] `fooshop init` creates a store via AI generation
- [ ] `fooshop products add` uploads file and creates product
- [ ] `fooshop products list` shows table of products
- [ ] `fooshop products edit <slug>` updates a product
- [ ] `fooshop products delete <slug>` deletes with confirmation
- [ ] `fooshop orders list` shows orders table
- [ ] `fooshop orders list --last 7d` filters by period
- [ ] `fooshop analytics` shows KPIs and tables
- [ ] `fooshop config` shows current configuration
- [ ] `fooshop open` opens store in browser
- [ ] `--json` flag outputs raw JSON on supported commands
- [ ] All 31 CLI tests pass